### PR TITLE
Update instructions for ESPHome development on Windows

### DIFF
--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -119,8 +119,8 @@ Once you've pushed your branch, if you wish, you can
 
 ???+ Windows
 
-    # Testing Development Changes on Windows
-
+    ## Testing Development Changes on Windows
+    
     On Windows, One way to test changes is by creating a branch in your remote fork of the main ESPHome GitHub repo,
     and then installing it just like [Installing ESPHome Manually](https://esphome.io/guides/installing_esphome) with the below command:
 

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -125,7 +125,7 @@ Once you've pushed your branch, if you wish, you can
 
     - Create a branch in your remote fork of the main ESPHome GitHub repo
     - Install from your fork in the same manner you would
-[install ESPHome manually](https://esphome.io/guides/installing_esphome) but with one of the following commands:
+      [install ESPHome manually](https://esphome.io/guides/installing_esphome) but with one of the following commands:
 
         ```bash
         pip install --pre https://github.com/username/esphome/archive/branch.zip

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -117,17 +117,18 @@ git push -u origin my-new-feature
 Once you've pushed your branch, if you wish, you can
 [submit your work for integration into ESPHome](submitting-your-work.md).
 
-# Testing Development Changes on Windows
+???+ # Testing Development Changes on Windows
 
-On Windows, One way to test changes is by creating a branch in your remote fork of the main ESPHome GitHub repo,
-and then installing it just like "installing ESPHome Manually" section with the below command:
-Here, username and branch is your username and ESPHome fork branch name respectively on Github.
+    On Windows, One way to test changes is by creating a branch in your remote fork of the main ESPHome GitHub repo,
+    and then installing it just like [Installing ESPHome Manually](https://esphome.io/guides/installing_esphome) with the below command:
 
-```bash
-pip install --pre https://github.com/username/esphome/archive/branch.zip
-```
-OR
-```bash
-pip install -U git+https://github.com/username/esphome.git@branch --force-reinstall
-```
-The `--force-reinstall` flag is important for testing small changes!
+    Here, username and branch is your username and ESPHome fork branch name respectively on Github.
+
+    ```bash
+    pip install --pre https://github.com/username/esphome/archive/branch.zip
+    ```
+    OR
+    ```bash
+    pip install -U git+https://github.com/username/esphome.git@branch --force-reinstall
+    ```
+    The `--force-reinstall` flag is important for testing small changes!

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -121,10 +121,12 @@ Once you've pushed your branch, if you wish, you can
 
     ## Testing Development Changes on Windows
     
-    On Windows, One way to test changes is by creating a branch in your remote fork of the main ESPHome GitHub repo,
-    and then installing it just like [Installing ESPHome Manually](https://esphome.io/guides/installing_esphome) with the below command:
+    To test changes when using Windows:
+    - Create a branch in your remote fork of the main ESPHome GitHub repo
+    - Install from your fork in the same manner you would
+      [install ESPHome manually](https://esphome.io/guides/installing_esphome) but with the following command:
 
-    Here, username and branch is your username and ESPHome fork branch name respectively on Github.
+    Here, `username` and `branch` are (respectively) your GitHub username and branch name in your ESPHome fork on Github.
 
     ```bash
     pip install --pre https://github.com/username/esphome/archive/branch.zip

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -117,7 +117,7 @@ git push -u origin my-new-feature
 Once you've pushed your branch, if you wish, you can
 [submit your work for integration into ESPHome](submitting-your-work.md).
 
-???+ # Testing Development Changes on Windows
+???+ Testing Development Changes on Windows
 
     On Windows, One way to test changes is by creating a branch in your remote fork of the main ESPHome GitHub repo,
     and then installing it just like [Installing ESPHome Manually](https://esphome.io/guides/installing_esphome) with the below command:

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -121,12 +121,13 @@ Once you've pushed your branch, if you wish, you can
 
 On Windows, One way to test changes is by creating a branch in your remote fork of the main ESPHome GitHub repo,
 and then installing it just like "installing ESPHome Manually" section with the below command:
+Here, username and branch is your username and ESPHome fork branch name respectively on Github.
 
 ```bash
-pip install --pre https://github.com/username/esphome/archive/patch-2.zip
+pip install --pre https://github.com/username/esphome/archive/branch.zip
 ```
 OR
 ```bash
-pip install -U git+https://github.com/username/esphome.git@patch-2 --force-reinstall
+pip install -U git+https://github.com/username/esphome.git@branch --force-reinstall
 ```
-The `--force-reinstall` flag is important!
+The `--force-reinstall` flag is important for testing small changes!

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -7,8 +7,8 @@ In short, ESPHome is set up to use a Python virtual environment.
 This guide will walk you through the steps to set up an environment you can use for development.
 
 !!!note
-    These instructions that follow apply for Linux and macOS. Windows users can still develop ESPHome and its
-    components, but the process is slightly different and not covered (yet) in this guide.
+    The instructions that follow apply for Linux and macOS. Windows users can still develop ESPHome and its
+    components, but the process is slightly different and covered at the bottom of this guide.
 
 ## Requirements
 
@@ -116,3 +116,17 @@ git push -u origin my-new-feature
 
 Once you've pushed your branch, if you wish, you can
 [submit your work for integration into ESPHome](submitting-your-work.md).
+
+# Testing Development Changes on Windows
+
+On Windows, One way to test changes is by creating a branch in your remote fork of the main ESPHome GitHub repo,
+and then installing it just like "installing ESPHome Manually" section with the below command:
+
+```bash
+pip install --pre https://github.com/username/esphome/archive/patch-2.zip
+```
+OR
+```bash
+pip install -U git+https://github.com/username/esphome.git@patch-2 --force-reinstall
+```
+The `--force-reinstall` flag is important!

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -122,6 +122,7 @@ Once you've pushed your branch, if you wish, you can
     ## Testing Development Changes on Windows
     
     To test changes when using Windows:
+
     - Create a branch in your remote fork of the main ESPHome GitHub repo
     - Install from your fork in the same manner you would
       [install ESPHome manually](https://esphome.io/guides/installing_esphome) but with the following command:

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -117,7 +117,9 @@ git push -u origin my-new-feature
 Once you've pushed your branch, if you wish, you can
 [submit your work for integration into ESPHome](submitting-your-work.md).
 
-???+ Testing Development Changes on Windows
+???+ Windows
+
+    # Testing Development Changes on Windows
 
     On Windows, One way to test changes is by creating a branch in your remote fork of the main ESPHome GitHub repo,
     and then installing it just like [Installing ESPHome Manually](https://esphome.io/guides/installing_esphome) with the below command:

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -125,15 +125,16 @@ Once you've pushed your branch, if you wish, you can
 
     - Create a branch in your remote fork of the main ESPHome GitHub repo
     - Install from your fork in the same manner you would
-      [install ESPHome manually](https://esphome.io/guides/installing_esphome) but with the following command:
+[install ESPHome manually](https://esphome.io/guides/installing_esphome) but with one of the following commands:
 
-    Here, `username` and `branch` are (respectively) your GitHub username and branch name in your ESPHome fork on Github.
+        ```bash
+        pip install --pre https://github.com/username/esphome/archive/branch.zip
+        ```
+        OR
+        ```bash
+        pip install -U git+https://github.com/username/esphome.git@branch --force-reinstall
+        ```
 
-    ```bash
-    pip install --pre https://github.com/username/esphome/archive/branch.zip
-    ```
-    OR
-    ```bash
-    pip install -U git+https://github.com/username/esphome.git@branch --force-reinstall
-    ```
-    The `--force-reinstall` flag is important for testing small changes!
+    Note that `username` and `branch` are (respectively) your GitHub username and branch name in your ESPHome fork on Github.
+
+    The `--force-reinstall` flag is important for testing changes!


### PR DESCRIPTION
Update preliminary instructions for ESPHome development on Windows

These instructions are tested with git version 2.50.0.windows.1 on Windows 11 , Python 3.13.4