### PR TITLE
Update development env docs for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **Want to contribute?**
 
 - Clone this repo
+- install requirements: `pip install -r requirements.txt`
 - Run the server:
     - `mkdocs serve`
     - Specify a port: `mkdocs serve -a localhost:8001`

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -59,8 +59,13 @@ This will create a Python virtual environment and install various other requirem
 To use the virtual environment, you need to activate it. This needs to be done for each new terminal session and is
 done by running:
 
+Linux/macOS:
 ```bash
 source venv/bin/activate
+```
+Windows (PowerShell):
+```powershell
+venv\Scripts\Activate
 ```
 
 ## Run `esphome`


### PR DESCRIPTION
I noticed that the development setup for esphome has Windows separate at the bottom with different instructions and I'm not sure why?
And when actually reading the script/setup.bat file it even prints out the correct command to activate the virtual environment.

- I cloned the repo.
- I ran scripts/setup
- I ran venv/Scripts/activate
- Compile a sample config file with no issues

Also. The Readme contribute section does not mention to install the required pip packages (like mkdocs)