### PR TITLE
Add blog post: Trigger trampolines eliminated (#15174, #15198, #15199, #15200)

### DIFF
--- a/docs/blog/posts/2026-04-09-trigger-trampoline-elimination.md
+++ b/docs/blog/posts/2026-04-09-trigger-trampoline-elimination.md
@@ -121,17 +121,21 @@ this->parent_->add_on_state_callback([this](MediaPlayerState state) {
 
 ### Python codegen migration
 
-If your external component uses `build_automation()` with any of the removed trigger classes, migrate to `build_callback_automation()`:
+If your external component uses `build_automation()` with trigger classes, migrate to `build_callback_automations()` ([PR #15246](https://github.com/esphome/esphome/pull/15246)):
 
 ```python
 # Before
 from esphome import automation
 
 MyStateTrigger = my_ns.class_("MyStateTrigger", automation.Trigger.template(cg.bool_))
+MyPressTrigger = my_ns.class_("MyPressTrigger", automation.Trigger.template())
 
 CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_ON_STATE): automation.validate_automation(
         {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MyStateTrigger)}
+    ),
+    cv.Optional(CONF_ON_PRESS): automation.validate_automation(
+        {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MyPressTrigger)}
     ),
 })
 
@@ -139,21 +143,27 @@ async def to_code(config):
     for conf in config.get(CONF_ON_STATE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [(bool, "x")], conf)
+    for conf in config.get(CONF_ON_PRESS, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
 ```
 
 ```python
-# After — no trigger class needed, no CONF_TRIGGER_ID in schema
+# After — no trigger classes needed, no CONF_TRIGGER_ID in schema
 from esphome import automation
+
+_CALLBACK_AUTOMATIONS = (
+    automation.CallbackAutomation(CONF_ON_STATE, "add_on_state_callback", [(bool, "x")]),
+    automation.CallbackAutomation(CONF_ON_PRESS, "add_on_press_callback"),
+)
 
 CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_ON_STATE): automation.validate_automation({}),
+    cv.Optional(CONF_ON_PRESS): automation.validate_automation({}),
 })
 
 async def to_code(config):
-    for conf in config.get(CONF_ON_STATE, []):
-        await automation.build_callback_automation(
-            var, "add_on_state_callback", [(bool, "x")], conf
-        )
+    await automation.build_callback_automations(var, config, _CALLBACK_AUTOMATIONS)
 ```
 
 `build_automation()` and all `Trigger` subclasses remain available for triggers that need mutable state beyond a single `Automation*` pointer.

--- a/docs/blog/posts/2026-04-09-trigger-trampoline-elimination.md
+++ b/docs/blog/posts/2026-04-09-trigger-trampoline-elimination.md
@@ -9,16 +9,16 @@ comments: true
 
 Common entity trigger classes have been replaced with lightweight forwarder structs that fit inline in the callback system. The new `build_callback_automation()` API eliminates per-trigger object allocations. Several entity callback signatures have also changed to pass state as an argument.
 
-This is a **developer breaking change** for external components in **ESPHome 2026.4.0 and later**.
+This is a **breaking change** for external components in **ESPHome 2026.4.0 and later**.
 
 <!-- more -->
 
 ## Background
 
-**[PR #15174](https://github.com/esphome/esphome/pull/15174): Eliminate trigger trampolines with deduplicated forwarder structs**
-**[PR #15198](https://github.com/esphome/esphome/pull/15198): alarm_control_panel — Migrate triggers to callback automation**
-**[PR #15199](https://github.com/esphome/esphome/pull/15199): lock — Migrate LockStateTrigger to callback automation**
-**[PR #15200](https://github.com/esphome/esphome/pull/15200): media_player — Migrate triggers to callback automation**
+- **[PR #15174](https://github.com/esphome/esphome/pull/15174):** Eliminate trigger trampolines with deduplicated forwarder structs
+- **[PR #15198](https://github.com/esphome/esphome/pull/15198):** `alarm_control_panel` — Migrate triggers to callback automation
+- **[PR #15199](https://github.com/esphome/esphome/pull/15199):** `lock` — Migrate LockStateTrigger to callback automation
+- **[PR #15200](https://github.com/esphome/esphome/pull/15200):** `media_player` — Migrate triggers to callback automation
 
 Previously, each automation trigger created a separate C++ object that existed solely to forward a callback to an `Automation`. For example:
 
@@ -73,7 +73,7 @@ The `trigger_` protected field on `Automation` (set in constructor, never read) 
 
 ## Who This Affects
 
-1. **External components registering callbacks on alarm_control_panel, lock, or media_player** — must update callback signature to accept the state parameter
+1. **External components registering callbacks on `alarm_control_panel`, `lock`, or `media_player`** — must update callback signature to accept the state parameter
 2. **External components accessing `Automation::trigger_`** — this field no longer exists
 
 ## Migration Guide
@@ -82,39 +82,39 @@ The `trigger_` protected field on `Automation` (set in constructor, never read) 
 
 ```cpp
 // alarm_control_panel — Before
-panel->add_on_state_callback([this]() {
-  auto state = this->panel_->get_state();
+this->parent_->add_on_state_callback([this]() {
+  auto state = this->parent_->get_state();
   // ...
 });
 
 // After
-panel->add_on_state_callback([this](AlarmControlPanelState state) {
+this->parent_->add_on_state_callback([this](AlarmControlPanelState state) {
   // state is passed directly, no need to call get_state()
 });
 ```
 
 ```cpp
 // lock — Before
-lock->add_on_state_callback([this]() {
-  auto state = this->lock_->state;
+this->parent_->add_on_state_callback([this]() {
+  auto state = this->parent_->state;
   // ...
 });
 
 // After
-lock->add_on_state_callback([this](LockState state) {
+this->parent_->add_on_state_callback([this](LockState state) {
   // state is passed directly
 });
 ```
 
 ```cpp
 // media_player — Before
-player->add_on_state_callback([this]() {
-  auto state = this->player_->state;
+this->parent_->add_on_state_callback([this]() {
+  auto state = this->parent_->state;
   // ...
 });
 
 // After
-player->add_on_state_callback([this](MediaPlayerState state) {
+this->parent_->add_on_state_callback([this](MediaPlayerState state) {
   // state is passed directly
 });
 ```
@@ -127,18 +127,18 @@ If your external component uses `build_automation()` with any of the removed tri
 # Before
 from esphome import automation
 
-TurnOnTrigger = my_ns.class_("TurnOnTrigger", automation.Trigger.template())
+MyStateTrigger = my_ns.class_("MyStateTrigger", automation.Trigger.template(cg.bool_))
 
 CONFIG_SCHEMA = cv.Schema({
-    cv.Optional(CONF_ON_TURN_ON): automation.validate_automation(
-        {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(TurnOnTrigger)}
+    cv.Optional(CONF_ON_STATE): automation.validate_automation(
+        {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MyStateTrigger)}
     ),
 })
 
 async def to_code(config):
-    for conf in config.get(CONF_ON_TURN_ON, []):
+    for conf in config.get(CONF_ON_STATE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
+        await automation.build_automation(trigger, [(bool, "x")], conf)
 ```
 
 ```python
@@ -146,11 +146,11 @@ async def to_code(config):
 from esphome import automation
 
 CONFIG_SCHEMA = cv.Schema({
-    cv.Optional(CONF_ON_TURN_ON): automation.validate_automation({}),
+    cv.Optional(CONF_ON_STATE): automation.validate_automation({}),
 })
 
 async def to_code(config):
-    for conf in config.get(CONF_ON_TURN_ON, []):
+    for conf in config.get(CONF_ON_STATE, []):
         await automation.build_callback_automation(
             var, "add_on_state_callback", [(bool, "x")], conf
         )
@@ -180,6 +180,6 @@ If you have questions about migrating your external component, please ask in:
 ## Related Documentation
 
 - [PR #15174: Eliminate trigger trampolines with deduplicated forwarder structs](https://github.com/esphome/esphome/pull/15174)
-- [PR #15198: alarm_control_panel — Migrate triggers to callback automation](https://github.com/esphome/esphome/pull/15198)
-- [PR #15199: lock — Migrate LockStateTrigger to callback automation](https://github.com/esphome/esphome/pull/15199)
-- [PR #15200: media_player — Migrate triggers to callback automation](https://github.com/esphome/esphome/pull/15200)
+- [PR #15198: Migrate alarm\_control\_panel triggers to callback automation](https://github.com/esphome/esphome/pull/15198)
+- [PR #15199: Migrate lock triggers to callback automation](https://github.com/esphome/esphome/pull/15199)
+- [PR #15200: Migrate media\_player triggers to callback automation](https://github.com/esphome/esphome/pull/15200)

--- a/docs/blog/posts/2026-04-09-trigger-trampoline-elimination.md
+++ b/docs/blog/posts/2026-04-09-trigger-trampoline-elimination.md
@@ -43,34 +43,7 @@ The forwarder fits in the `Callback::ctx_` field — no additional storage neede
 
 ## What's Changing
 
-### 1. Trigger classes removed
-
-The following trigger classes are removed and replaced with forwarder structs:
-
-**Core entities (PR #15174):**
-
-- `ButtonPressTrigger`
-- `SensorStateTrigger`, `SensorRawStateTrigger`
-- `PressTrigger`, `ReleaseTrigger`, `StateTrigger`, `StateChangeTrigger` (binary_sensor)
-- `SwitchStateTrigger`, `SwitchTurnOnTrigger`, `SwitchTurnOffTrigger`
-- `TextSensorStateTrigger`, `TextSensorStateRawTrigger`
-- `NumberStateTrigger`
-- `EventTrigger`
-
-**alarm_control_panel (PR #15198):**
-
-- `StateTrigger`, `ClearedTrigger`, `ChimeTrigger`, `ReadyTrigger`
-- `TriggeredTrigger`, `ArmingTrigger`, `PendingTrigger`, `ArmedHomeTrigger`, `ArmedNightTrigger`, `ArmedAwayTrigger`, `DisarmedTrigger`
-
-**lock (PR #15199):**
-
-- `LockStateTrigger<State>`, `LockLockTrigger`, `LockUnlockTrigger`
-
-**media_player (PR #15200):**
-
-- `StateTrigger`, `MediaPlayerStateTrigger<State>`, `IdleTrigger`, `PlayTrigger`, `PauseTrigger`, `AnnouncementTrigger`, `OnTrigger`, `OffTrigger`
-
-### 2. Callback signatures changed
+### 1. Callback signatures changed
 
 Several entity callback signatures changed to pass state as an argument, enabling single-pointer forwarders:
 
@@ -94,15 +67,14 @@ template<typename F> void add_on_state_callback(F &&callback);
 // Callback signature: void(MediaPlayerState)
 ```
 
-### 3. Automation::trigger_ field removed
+### 2. Automation::trigger_ field removed
 
 The `trigger_` protected field on `Automation` (set in constructor, never read) has been removed.
 
 ## Who This Affects
 
-1. **External components that instantiate removed trigger classes** — must migrate to `build_callback_automation()` or register callbacks directly
-2. **External components registering callbacks on alarm_control_panel, lock, or media_player** — must update callback signature to accept the state parameter
-3. **External components accessing `Automation::trigger_`** — this field no longer exists
+1. **External components registering callbacks on alarm_control_panel, lock, or media_player** — must update callback signature to accept the state parameter
+2. **External components accessing `Automation::trigger_`** — this field no longer exists
 
 ## Migration Guide
 
@@ -194,12 +166,6 @@ async def to_code(config):
 ## Finding Code That Needs Updates
 
 ```bash
-# Find references to removed trigger classes
-grep -rn 'ButtonPressTrigger\|SensorStateTrigger\|PressTrigger\|ReleaseTrigger' your_component/
-grep -rn 'SwitchStateTrigger\|TextSensorStateTrigger\|NumberStateTrigger' your_component/
-grep -rn 'LockStateTrigger\|LockLockTrigger\|LockUnlockTrigger' your_component/
-grep -rn 'MediaPlayerStateTrigger\|IdleTrigger\|PlayTrigger' your_component/
-
 # Find alarm_control_panel/lock/media_player callback registrations
 grep -rn 'add_on_state_callback' your_component/
 ```

--- a/docs/blog/posts/2026-04-09-trigger-trampoline-elimination.md
+++ b/docs/blog/posts/2026-04-09-trigger-trampoline-elimination.md
@@ -1,0 +1,219 @@
+---
+date: 2026-04-09
+authors:
+  - bdraco
+comments: true
+---
+
+# Trigger Trampolines Eliminated with build_callback_automation
+
+Common entity trigger classes have been replaced with lightweight forwarder structs that fit inline in the callback system. The new `build_callback_automation()` API eliminates per-trigger object allocations. Several entity callback signatures have also changed to pass state as an argument.
+
+This is a **developer breaking change** for external components in **ESPHome 2026.4.0 and later**.
+
+<!-- more -->
+
+## Background
+
+**[PR #15174](https://github.com/esphome/esphome/pull/15174): Eliminate trigger trampolines with deduplicated forwarder structs**
+**[PR #15198](https://github.com/esphome/esphome/pull/15198): alarm_control_panel — Migrate triggers to callback automation**
+**[PR #15199](https://github.com/esphome/esphome/pull/15199): lock — Migrate LockStateTrigger to callback automation**
+**[PR #15200](https://github.com/esphome/esphome/pull/15200): media_player — Migrate triggers to callback automation**
+
+Previously, each automation trigger created a separate C++ object that existed solely to forward a callback to an `Automation`. For example:
+
+```
+button press → callback → ButtonPressTrigger::trigger() → Automation::trigger()
+```
+
+Now a lightweight forwarder struct collapses this into the callback itself:
+
+```
+button press → callback → TriggerForwarder::operator()() → Automation::trigger()
+```
+
+The forwarder fits in the `Callback::ctx_` field — no additional storage needed.
+
+### Memory savings
+
+| Config | Platform | RAM Saved | Flash Saved |
+|--------|----------|-----------|-------------|
+| ratgdo (garage door) | ESP8266 | **88 bytes** | **224 bytes** |
+| multi-sensor device | ESP32-IDF | **208 bytes** | **280 bytes** |
+
+## What's Changing
+
+### 1. Trigger classes removed
+
+The following trigger classes are removed and replaced with forwarder structs:
+
+**Core entities (PR #15174):**
+
+- `ButtonPressTrigger`
+- `SensorStateTrigger`, `SensorRawStateTrigger`
+- `PressTrigger`, `ReleaseTrigger`, `StateTrigger`, `StateChangeTrigger` (binary_sensor)
+- `SwitchStateTrigger`, `SwitchTurnOnTrigger`, `SwitchTurnOffTrigger`
+- `TextSensorStateTrigger`, `TextSensorStateRawTrigger`
+- `NumberStateTrigger`
+- `EventTrigger`
+
+**alarm_control_panel (PR #15198):**
+
+- `StateTrigger`, `ClearedTrigger`, `ChimeTrigger`, `ReadyTrigger`
+- `TriggeredTrigger`, `ArmingTrigger`, `PendingTrigger`, `ArmedHomeTrigger`, `ArmedNightTrigger`, `ArmedAwayTrigger`, `DisarmedTrigger`
+
+**lock (PR #15199):**
+
+- `LockStateTrigger<State>`, `LockLockTrigger`, `LockUnlockTrigger`
+
+**media_player (PR #15200):**
+
+- `StateTrigger`, `MediaPlayerStateTrigger<State>`, `IdleTrigger`, `PlayTrigger`, `PauseTrigger`, `AnnouncementTrigger`, `OnTrigger`, `OffTrigger`
+
+### 2. Callback signatures changed
+
+Several entity callback signatures changed to pass state as an argument, enabling single-pointer forwarders:
+
+```cpp
+// alarm_control_panel — Before
+void add_on_state_callback(std::function<void()> &&callback);
+// After
+template<typename F> void add_on_state_callback(F &&callback);
+// Callback signature: void(AlarmControlPanelState)
+
+// lock — Before
+void add_on_state_callback(std::function<void()> &&callback);
+// After
+template<typename F> void add_on_state_callback(F &&callback);
+// Callback signature: void(LockState)
+
+// media_player — Before
+void add_on_state_callback(std::function<void()> &&callback);
+// After
+template<typename F> void add_on_state_callback(F &&callback);
+// Callback signature: void(MediaPlayerState)
+```
+
+### 3. Automation::trigger_ field removed
+
+The `trigger_` protected field on `Automation` (set in constructor, never read) has been removed.
+
+## Who This Affects
+
+1. **External components that instantiate removed trigger classes** — must migrate to `build_callback_automation()` or register callbacks directly
+2. **External components registering callbacks on alarm_control_panel, lock, or media_player** — must update callback signature to accept the state parameter
+3. **External components accessing `Automation::trigger_`** — this field no longer exists
+
+## Migration Guide
+
+### Callback signature changes
+
+```cpp
+// alarm_control_panel — Before
+panel->add_on_state_callback([this]() {
+  auto state = this->panel_->get_state();
+  // ...
+});
+
+// After
+panel->add_on_state_callback([this](AlarmControlPanelState state) {
+  // state is passed directly, no need to call get_state()
+});
+```
+
+```cpp
+// lock — Before
+lock->add_on_state_callback([this]() {
+  auto state = this->lock_->state;
+  // ...
+});
+
+// After
+lock->add_on_state_callback([this](LockState state) {
+  // state is passed directly
+});
+```
+
+```cpp
+// media_player — Before
+player->add_on_state_callback([this]() {
+  auto state = this->player_->state;
+  // ...
+});
+
+// After
+player->add_on_state_callback([this](MediaPlayerState state) {
+  // state is passed directly
+});
+```
+
+### Python codegen migration
+
+If your external component uses `build_automation()` with any of the removed trigger classes, migrate to `build_callback_automation()`:
+
+```python
+# Before
+from esphome import automation
+
+TurnOnTrigger = my_ns.class_("TurnOnTrigger", automation.Trigger.template())
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.Optional(CONF_ON_TURN_ON): automation.validate_automation(
+        {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(TurnOnTrigger)}
+    ),
+})
+
+async def to_code(config):
+    for conf in config.get(CONF_ON_TURN_ON, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+```
+
+```python
+# After — no trigger class needed, no CONF_TRIGGER_ID in schema
+from esphome import automation
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.Optional(CONF_ON_TURN_ON): automation.validate_automation({}),
+})
+
+async def to_code(config):
+    for conf in config.get(CONF_ON_TURN_ON, []):
+        await automation.build_callback_automation(
+            var, "add_on_state_callback", [(bool, "x")], conf
+        )
+```
+
+`build_automation()` and all `Trigger` subclasses remain available for triggers that need mutable state beyond a single `Automation*` pointer.
+
+## Timeline
+
+- **ESPHome 2026.4.0 (April 2026):** Trigger classes removed, callback signatures changed
+- No deprecation period — these are signature changes and class removals
+
+## Finding Code That Needs Updates
+
+```bash
+# Find references to removed trigger classes
+grep -rn 'ButtonPressTrigger\|SensorStateTrigger\|PressTrigger\|ReleaseTrigger' your_component/
+grep -rn 'SwitchStateTrigger\|TextSensorStateTrigger\|NumberStateTrigger' your_component/
+grep -rn 'LockStateTrigger\|LockLockTrigger\|LockUnlockTrigger' your_component/
+grep -rn 'MediaPlayerStateTrigger\|IdleTrigger\|PlayTrigger' your_component/
+
+# Find alarm_control_panel/lock/media_player callback registrations
+grep -rn 'add_on_state_callback' your_component/
+```
+
+## Questions?
+
+If you have questions about migrating your external component, please ask in:
+
+- [ESPHome Discord](https://discord.gg/KhAMKrd) - #devs channel
+- [ESPHome GitHub Discussions](https://github.com/esphome/esphome/discussions)
+
+## Related Documentation
+
+- [PR #15174: Eliminate trigger trampolines with deduplicated forwarder structs](https://github.com/esphome/esphome/pull/15174)
+- [PR #15198: alarm_control_panel — Migrate triggers to callback automation](https://github.com/esphome/esphome/pull/15198)
+- [PR #15199: lock — Migrate LockStateTrigger to callback automation](https://github.com/esphome/esphome/pull/15199)
+- [PR #15200: media_player — Migrate triggers to callback automation](https://github.com/esphome/esphome/pull/15200)


### PR DESCRIPTION
## Summary
- Blog post documenting elimination of trigger trampoline objects with `build_callback_automation()`
- Covers callback signature changes for alarm_control_panel, lock, and media_player
- Lists all removed trigger classes and migration paths

## Related
- esphome/esphome#15174
- esphome/esphome#15198
- esphome/esphome#15199
- esphome/esphome#15200