### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   lock:
-    uses: esphome/workflows/.github/workflows/lock.yml@main
+    uses: esphome/workflows/.github/workflows/lock.yml@ea419066f18ad411a71edde3c2c76e2b801789de  # main

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   lock:
-    uses: esphome/workflows/.github/workflows/lock.yml@ea419066f18ad411a71edde3c2c76e2b801789de  # 2025.10.0
+    uses: esphome/workflows/.github/workflows/lock.yml@e7eee2a828517c042794a831f75310959fbf2a16  # 2025.10.0

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   lock:
-    uses: esphome/workflows/.github/workflows/lock.yml@ea419066f18ad411a71edde3c2c76e2b801789de  # main
+    uses: esphome/workflows/.github/workflows/lock.yml@ea419066f18ad411a71edde3c2c76e2b801789de  # 2025.10.0


### PR DESCRIPTION
## Summary

Pin all GitHub Action and reusable workflow references to their full commit SHAs
instead of mutable tags or branch names.

Closes #128


## Why?

Referencing actions by tag (e.g., `actions/checkout@v4`) is convenient but
carries a supply-chain risk: tags are mutable and can be force-pushed to point
at arbitrary commits. If an action's tag is compromised, every workflow that
references it by tag will silently run the attacker's code.

Pinning to a full 40-character commit SHA (e.g.,
`actions/checkout@11bd719...`) makes the reference immutable. Even if a tag is
tampered with, workflows pinned to a SHA will continue to use the exact code
that was reviewed and trusted.

A version comment is included next to each SHA for readability
(e.g., `actions/checkout@11bd719... # v4.2.2`).

## References

- [GitHub Blog: Four tips to keep your GitHub Actions workflows secure](https://github.blog/open-source/four-tips-to-keep-your-github-actions-workflows-secure/#use-specific-action-version-tags)
- [GitHub Docs: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [GitHub Docs: Enforcing SHA pinning for actions](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#requiring-workflows-to-use-pinned-versions-of-actions)
