### PR TITLE
Document cg.templatable pairing for TEMPLATABLE_VALUE setters

### DIFF
--- a/docs/architecture/components/automations.md
+++ b/docs/architecture/components/automations.md
@@ -257,7 +257,7 @@ template<typename... Ts> class SetValueAction : public Action<Ts...> {
 };
 ```
 
-Values passed to a `TEMPLATABLE_VALUE` setter from Python codegen **must** be wrapped with `cg.templatable()`, even when the value is a literal constant. The setter stores a `TemplatableFn`/`TemplatableValue` and cannot be assigned a raw C++ value directly:
+Values passed to a `TEMPLATABLE_VALUE` setter from Python codegen should always be wrapped with `cg.templatable()`, even when the value is a literal constant. The setter's storage is `TemplatableFn` for trivially copyable types (`bool`, `int`, `float`, enums, pointers) and `TemplatableValue` otherwise; `TemplatableFn` holds only a function pointer and will not accept a raw C++ value, so failing to wrap compiles on 2026.3.x and earlier only because `TemplatableValue` had an implicit raw-constant constructor:
 
 ```python
 @automation.register_action(
@@ -274,12 +274,14 @@ async def set_state_to_code(
 ) -> MockObj:
     parent = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, parent)
-    template_ = await cg.templatable(config[CONF_STATE], args, bool)
+    template_ = await cg.templatable(config[CONF_STATE], args, cg.bool_)
     cg.add(var.set_state(template_))
     return var
 ```
 
-Passing a raw value (`cg.add(var.set_state(config[CONF_STATE]))`) may appear to work for literal constants on older ESPHome versions but fails to compile on 2026.4.0 and later, where trivially copyable types use `TemplatableFn` (4-byte function-pointer storage) with no implicit conversion from raw values. See the [TemplatableFn blog post](../../blog/posts/2026-04-09-templatable-fn.md) for details.
+Same imports as the earlier Python snippets on this page apply (`cg`, `cv`, `automation`, constants, typing aliases); `CONF_STATE` and `SetValueAction` are defined by the component itself.
+
+Passing a raw value such as `cg.add(var.set_state(config[CONF_STATE]))` worked on 2026.3.x and earlier for literal constants but fails to compile on 2026.4.0 and later, where trivially copyable types use `TemplatableFn` (4-byte function-pointer storage) with no implicit conversion from raw values. See the [TemplatableFn blog post](../../blog/posts/2026-04-09-templatable-fn.md) for details.
 
 ## Conditions
 

--- a/docs/architecture/components/automations.md
+++ b/docs/architecture/components/automations.md
@@ -257,6 +257,30 @@ template<typename... Ts> class SetValueAction : public Action<Ts...> {
 };
 ```
 
+Values passed to a `TEMPLATABLE_VALUE` setter from Python codegen **must** be wrapped with `cg.templatable()`, even when the value is a literal constant. The setter stores a `TemplatableFn`/`TemplatableValue` and cannot be assigned a raw C++ value directly:
+
+```python
+@automation.register_action(
+    "my_component.set_state",
+    SetValueAction,
+    cv.Schema({
+        cv.GenerateID(): cv.use_id(MyComponent),
+        cv.Required(CONF_STATE): cv.templatable(cv.boolean),
+    }),
+    synchronous=True,
+)
+async def set_state_to_code(
+    config: ConfigType, action_id: MockObj, template_arg: MockObj, args: TemplateArgsType
+) -> MockObj:
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    template_ = await cg.templatable(config[CONF_STATE], args, bool)
+    cg.add(var.set_state(template_))
+    return var
+```
+
+Passing a raw value (`cg.add(var.set_state(config[CONF_STATE]))`) may appear to work for literal constants on older ESPHome versions but fails to compile on 2026.4.0 and later, where trivially copyable types use `TemplatableFn` (4-byte function-pointer storage) with no implicit conversion from raw values. See the [TemplatableFn blog post](../../blog/posts/2026-04-09-templatable-fn.md) for details.
+
 ## Conditions
 
 Conditions are template classes that return a boolean to control automation flow.

--- a/docs/architecture/components/automations.md
+++ b/docs/architecture/components/automations.md
@@ -281,7 +281,7 @@ async def set_state_to_code(
 
 Same imports as the earlier Python snippets on this page apply (`cg`, `cv`, `automation`, constants, typing aliases); `CONF_STATE` and `SetValueAction` are defined by the component itself.
 
-Passing a raw value such as `cg.add(var.set_state(config[CONF_STATE]))` worked on 2026.3.x and earlier for literal constants but fails to compile on 2026.4.0 and later, where trivially copyable types use `TemplatableFn` (4-byte function-pointer storage) with no implicit conversion from raw values. See the [TemplatableFn blog post](../../blog/posts/2026-04-09-templatable-fn.md) for details.
+Passing a raw value such as `cg.add(var.set_state(config[CONF_STATE]))` worked on 2026.3.x and earlier for literal constants but fails to compile on 2026.4.0 and later, where trivially copyable types use `TemplatableFn` (4-byte function-pointer storage) where implicit conversion from raw values is not possible. See the [TemplatableFn blog post](../../blog/posts/2026-04-09-templatable-fn.md) for details.
 
 ## Conditions
 

--- a/docs/architecture/components/automations.md
+++ b/docs/architecture/components/automations.md
@@ -257,7 +257,7 @@ template<typename... Ts> class SetValueAction : public Action<Ts...> {
 };
 ```
 
-Values passed to a `TEMPLATABLE_VALUE` setter from Python codegen should always be wrapped with `cg.templatable()`, even when the value is a literal constant. The setter's storage is `TemplatableFn` for trivially copyable types (`bool`, `int`, `float`, enums, pointers) and `TemplatableValue` otherwise; `TemplatableFn` holds only a function pointer and will not accept a raw C++ value, so failing to wrap compiles on 2026.3.x and earlier only because `TemplatableValue` had an implicit raw-constant constructor:
+Values passed to a `TEMPLATABLE_VALUE` setter from Python codegen should always be wrapped with `cg.templatable()`, even when the value is a literal constant. The setter's storage is `TemplatableFn` for trivially copyable types (`bool`, `int`, `float`, enums, pointers) and `TemplatableValue` otherwise; `TemplatableFn` holds only a function pointer and will not accept a raw C++ value, so failing to wrap compiles on 2026.3.x and earlier only when the setter type is `TemplatableValue`, which accepts raw constants:
 
 ```python
 @automation.register_action(
@@ -281,7 +281,7 @@ async def set_state_to_code(
 
 Same imports as the earlier Python snippets on this page apply (`cg`, `cv`, `automation`, constants, typing aliases); `CONF_STATE` and `SetValueAction` are defined by the component itself.
 
-Passing a raw value such as `cg.add(var.set_state(config[CONF_STATE]))` worked on 2026.3.x and earlier for literal constants but fails to compile on 2026.4.0 and later, where trivially copyable types use `TemplatableFn` (4-byte function-pointer storage) where implicit conversion from raw values is not possible. See the [TemplatableFn blog post](../../blog/posts/2026-04-09-templatable-fn.md) for details.
+Passing a raw value such as `cg.add(var.set_state(config[CONF_STATE]))` worked on 2026.3.x and earlier for literal constants but fails to compile on 2026.4.0 and later, because trivially copyable types use `TemplatableFn` (pointer-sized function-pointer storage, 4 bytes on 32-bit platforms), for which implicit conversion from raw values is not possible. See the [TemplatableFn blog post](../../blog/posts/2026-04-09-templatable-fn.md) for details.
 
 ## Conditions
 

--- a/docs/blog/posts/2026-04-09-templatable-fn.md
+++ b/docs/blog/posts/2026-04-09-templatable-fn.md
@@ -127,4 +127,5 @@ If you have questions about migrating your external component, please ask in:
 
 ## Related Documentation
 
+- [Implementing Automations](../../architecture/components/automations.md) covers the full `TEMPLATABLE_VALUE` / `cg.templatable()` pairing for actions
 - [PR #15545: Add TemplatableFn for 4-byte function-pointer templatable storage](https://github.com/esphome/esphome/pull/15545)


### PR DESCRIPTION
The automations architecture page shows the C++ `TEMPLATABLE_VALUE` macro but never documented the Python codegen half, so the correct `cg.templatable()` pairing was never explicitly called out. Roughly 90% of the in-tree codebase got it right, but external component authors who copied from the broken 10%, or who tested only with literal constants, never hit a compile error; `TemplatableValue` had an implicit raw-constant constructor, so passing a raw value happened to work even though it was always the wrong pattern. That silent-pass ends on 2026.4.0+, where trivially copyable types are stored in `TemplatableFn` (function-pointer only) and raw values fail to compile. Follow-up esphome/esphome#15758 improves the resulting compile-time error so the root cause is more obvious.

Changes:
- Adds a paired Python `cg.templatable()` example alongside the existing C++ `TEMPLATABLE_VALUE` snippet in `docs/architecture/components/automations.md`, using `cg.bool_` to match repo idiom.
- Explains the storage split (`TemplatableFn` for trivially copyable types, `TemplatableValue` otherwise) and why the raw-value pattern compiled on 2026.3.x and earlier despite being incorrect.
- Adds a back-link from the TemplatableFn blog post to the automations architecture doc under Related Documentation.