### PR TITLE
Fix fan preset modes migration guide

### DIFF
--- a/docs/blog/posts/2026-04-09-climate-fan-custom-mode-storage.md
+++ b/docs/blog/posts/2026-04-09-climate-fan-custom-mode-storage.md
@@ -48,17 +48,23 @@ The old `ClimateTraits::set_supported_custom_fan_modes()` and `ClimateTraits::se
 
 ### Fan
 
-Preset modes are now set directly on the `Fan` entity:
+Preset modes are now set directly on the `Fan` entity. Unlike Climate, `Fan::get_traits()` is the virtual method itself, so the `get_traits()` override must wire the stored preset modes into the returned traits via `wire_preset_modes_()`:
 
 ```cpp
-// Before — set on traits in traits() override
+// Before — set on traits in get_traits() override
 fan::FanTraits get_traits() override {
   return fan::FanTraits(true, true, true, this->preset_modes_);
 }
 
-// After — set once during setup or codegen
+// After — set once during setup or codegen, wire into traits in get_traits()
 void setup() override {
   this->set_supported_preset_modes({"Auto", "Sleep", "Nature"});
+}
+
+fan::FanTraits get_traits() override {
+  fan::FanTraits traits(true, true, true);
+  this->wire_preset_modes_(traits);
+  return traits;
 }
 ```
 
@@ -106,15 +112,19 @@ fan::FanTraits get_traits() override {
   return fan::FanTraits(true, true, true, this->preset_modes_);
 }
 
-// After
+// After — get_traits() override must call wire_preset_modes_() to expose them
 void setup() override {
   this->set_supported_preset_modes({"Auto", "Sleep", "Nature"});
 }
 
 fan::FanTraits get_traits() override {
-  return fan::FanTraits(true, true, true);
+  fan::FanTraits traits(true, true, true);
+  this->wire_preset_modes_(traits);
+  return traits;
 }
 ```
+
+> **Note:** Unlike Climate — where the base class's non-virtual `get_traits()` wraps a virtual `traits()` and wires custom modes automatically — `Fan::get_traits()` is itself the virtual method overridden by components. The base class has no opportunity to inject preset modes, so each override must call `wire_preset_modes_()` explicitly. The internal `speed`, `template`, and `hbridge` fan components follow this pattern.
 
 ### Python codegen
 


### PR DESCRIPTION
The fan section of the 2026-04-09 custom mode storage blog claimed preset modes were wired into traits automatically; that is only true for climate. For fan, get_traits() is itself the virtual method, so each override must call wire_preset_modes_() explicitly, which is what the internal speed, template, and hbridge fans already do.

Updated both example blocks in the blog post, and added a short note explaining why climate and fan differ here.

Fixes https://github.com/esphome/esphome/issues/15827