### PR TITLE
Note App.wake_loop_isrsafe() on ESP8266

### DIFF
--- a/docs/architecture/components/advanced.md
+++ b/docs/architecture/components/advanced.md
@@ -303,7 +303,7 @@ No `#ifdef` guards, no socket dependency, no `AUTO_LOAD` — just call it.
 For ISR handlers (e.g. UART RX ISR, GPIO ISR), use `enable_loop_soon_any_context()` on your component, or `App.wake_loop_any_context()` if you just need to wake the loop. Both auto-detect ISR vs task context. Platform notes:
 
 - **ESP32:** ISR-safe via `vTaskNotifyGiveFromISR()`. A separate `App.wake_loop_isrsafe()` is also available when you already know you are in ISR context and want to forward the `xHigherPriorityTaskWoken` flag yourself.
-- **ESP8266:** ISR-safe via `esp_schedule()`, which is IRAM. The `wake_loop_isrsafe()` variant is not provided since ESP8266 does not use FreeRTOS task notifications.
+- **ESP8266:** ISR-safe via `esp_schedule()`, which is IRAM. `App.wake_loop_isrsafe()` is also available; it takes no argument since ESP8266 has no FreeRTOS task to notify, and the body inlines into the `IRAM_ATTR` caller so it runs from IRAM automatically.
 - **RP2040:** ISR-safe. The wake body is inlined into `enable_loop_soon_any_context()`, which is placed in `.time_critical` RAM via `IRAM_ATTR`.
 - **LibreTiny:** ISR-safe via `vTaskNotifyGiveFromISR()` (same path as ESP32); `App.wake_loop_isrsafe()` is also available. `IRAM_ATTR` places handlers in executable RAM as expected, except on BK72xx where it is a no-op — the Beken SDK wraps every flash op in `GLOBAL_INT_DISABLE()` (FIQ+IRQ masked), so flash-resident ISR handlers are safe.
 - **Zephyr:** wake is a no-op, so enabling the loop from any context takes effect on the next loop iteration.

--- a/docs/architecture/components/advanced.md
+++ b/docs/architecture/components/advanced.md
@@ -303,7 +303,7 @@ No `#ifdef` guards, no socket dependency, no `AUTO_LOAD` — just call it.
 For ISR handlers (e.g. UART RX ISR, GPIO ISR), use `enable_loop_soon_any_context()` on your component, or `App.wake_loop_any_context()` if you just need to wake the loop. Both auto-detect ISR vs task context. Platform notes:
 
 - **ESP32:** ISR-safe via `vTaskNotifyGiveFromISR()`. A separate `App.wake_loop_isrsafe()` is also available when you already know you are in ISR context and want to forward the `xHigherPriorityTaskWoken` flag yourself.
-- **ESP8266:** ISR-safe via `esp_schedule()`, which is IRAM. `App.wake_loop_isrsafe()` is also available; it takes no argument since ESP8266 has no FreeRTOS task to notify, and the body is implemented inline and typically inlines into the `IRAM_ATTR` caller. For ISR safety, ensure the called code is IRAM-resident.
+- **ESP8266:** ISR-safe via `esp_schedule()`, which is IRAM. `App.wake_loop_isrsafe()` is also available; it takes no arguments since ESP8266 has no FreeRTOS task to notify, and the body is implemented inline and typically inlines into the `IRAM_ATTR` caller. For ISR safety, ensure the called code is IRAM-resident.
 - **RP2040:** ISR-safe. The wake body is inlined into `enable_loop_soon_any_context()`, which is placed in `.time_critical` RAM via `IRAM_ATTR`.
 - **LibreTiny:** ISR-safe via `vTaskNotifyGiveFromISR()` (same path as ESP32); `App.wake_loop_isrsafe()` is also available. `IRAM_ATTR` places handlers in executable RAM as expected, except on BK72xx where it is a no-op — the Beken SDK wraps every flash op in `GLOBAL_INT_DISABLE()` (FIQ+IRQ masked), so flash-resident ISR handlers are safe.
 - **Zephyr:** wake is a no-op, so enabling the loop from any context takes effect on the next loop iteration.

--- a/docs/architecture/components/advanced.md
+++ b/docs/architecture/components/advanced.md
@@ -303,7 +303,7 @@ No `#ifdef` guards, no socket dependency, no `AUTO_LOAD` — just call it.
 For ISR handlers (e.g. UART RX ISR, GPIO ISR), use `enable_loop_soon_any_context()` on your component, or `App.wake_loop_any_context()` if you just need to wake the loop. Both auto-detect ISR vs task context. Platform notes:
 
 - **ESP32:** ISR-safe via `vTaskNotifyGiveFromISR()`. A separate `App.wake_loop_isrsafe()` is also available when you already know you are in ISR context and want to forward the `xHigherPriorityTaskWoken` flag yourself.
-- **ESP8266:** ISR-safe via `esp_schedule()`, which is IRAM. `App.wake_loop_isrsafe()` is also available; it takes no argument since ESP8266 has no FreeRTOS task to notify, and the body inlines into the `IRAM_ATTR` caller so it runs from IRAM automatically.
+- **ESP8266:** ISR-safe via `esp_schedule()`, which is IRAM. `App.wake_loop_isrsafe()` is also available; it takes no argument since ESP8266 has no FreeRTOS task to notify, and the body is implemented inline and typically inlines into the `IRAM_ATTR` caller. For ISR safety, ensure the called code is IRAM-resident.
 - **RP2040:** ISR-safe. The wake body is inlined into `enable_loop_soon_any_context()`, which is placed in `.time_critical` RAM via `IRAM_ATTR`.
 - **LibreTiny:** ISR-safe via `vTaskNotifyGiveFromISR()` (same path as ESP32); `App.wake_loop_isrsafe()` is also available. `IRAM_ATTR` places handlers in executable RAM as expected, except on BK72xx where it is a no-op — the Beken SDK wraps every flash op in `GLOBAL_INT_DISABLE()` (FIQ+IRQ masked), so flash-resident ISR handlers are safe.
 - **Zephyr:** wake is a no-op, so enabling the loop from any context takes effect on the next loop iteration.


### PR DESCRIPTION
Follow-up to esphome/esphome#15797, which exposes `App.wake_loop_isrsafe()` on ESP8266. The Waking from ISR section previously said the variant was not provided on ESP8266; that is no longer accurate, so the bullet now notes the new entry point, explains the no-argument signature (no FreeRTOS task to notify), and points out that the body inlines into the `IRAM_ATTR` caller so it ends up in IRAM automatically.