### PR TITLE
[architecture] Document loop() vs scheduler tradeoffs after main-loop cadence fix

### DIFF
--- a/docs/architecture/components/advanced.md
+++ b/docs/architecture/components/advanced.md
@@ -281,12 +281,14 @@ Each main-loop tick has two phases. **Phase A** runs every tick (drains wake not
 
 ### RAM cost
 
-`set_timeout`, `set_interval`, and `defer` store callbacks in `std::function`, which has an ~8-byte small-buffer optimization. **Captures larger than 8 bytes spill to heap allocation**, fragmenting the heap over time. A `loop()` method needs no allocation and no capture — `this` is already available.
+`set_timeout`, `set_interval`, and `defer` store callbacks in `std::function`, which has an ~8-byte small-buffer optimization. **Captures larger than 8 bytes spill to heap allocation**, fragmenting the heap over time. Each registration adds its own `std::function` — three timers means three allocations.
 
 ```cpp
 this->set_interval(1000, [this]() { this->tick_(); });               // SBO-safe (one pointer)
 this->set_interval(1000, [this, addr, name]() { this->ping_(...); }); // heap-allocated (> 8 bytes)
 ```
+
+A `loop()` method costs one pointer in the application's `looping_components_` list per active component (regardless of how many distinct tasks the loop body performs) and no per-call allocation — `this` is already available. So a component doing three things at three different cadences via gated branches in `loop()` is one pointer of overhead; the same work split across three `set_interval` registrations is three `std::function`s plus their scheduler-entry storage.
 
 ### Other primitives
 

--- a/docs/architecture/components/advanced.md
+++ b/docs/architecture/components/advanced.md
@@ -4,10 +4,10 @@ This section covers advanced component development topics in ESPHome. These feat
 
 ## Component Loop Control
 
-ESPHome's main loop runs at the configured `loop_interval_` (default ~16 ms, ~62 Hz / ~3720 component-phase calls per minute), calling each registered component's `loop()` method. This is fast enough to feel responsive but still wastes CPU cycles for components that don't need continuous updates. The loop control API allows components to dynamically enable or disable their participation in the main loop.
+ESPHome's main loop runs at the configured `loop_interval_` (default ~16 ms, ~62.5 Hz / ~3750 component-phase calls per minute), calling each registered component's `loop()` method. This is fast enough to feel responsive but still wastes CPU cycles for components that don't need continuous updates. The loop control API allows components to dynamically enable or disable their participation in the main loop.
 
 !!! note "Cadence change in 2026.4.0"
-    Before [PR #15792](https://github.com/esphome/esphome/pull/15792), `loop()` could be emergently pulled forward to ~128 Hz (~2× the configured rate) when the scheduler had a timer due sooner than `loop_interval_/2`. Configs without scheduler activity weren't affected, but on devices with `set_interval`, `set_timeout`, or `PollingComponent` updates running at sub-`loop_interval_` cadences (common on busy ESP32 builds), every component's `loop()` ran at roughly double the documented rate. As of 2026.4.0, components run at the configured `loop_interval_` exactly, and `App.set_loop_interval()` actually saves power. See ["Choosing Between loop() and the Scheduler"](#choosing-between-loop-and-the-scheduler) below for what this means for periodic work.
+    Before [PR #15792](https://github.com/esphome/esphome/pull/15792), `loop()` could be emergently pulled forward to roughly double the configured rate when the scheduler had a timer due sooner than `loop_interval_/2`. Configs without scheduler activity weren't affected, but on devices with `set_interval`, `set_timeout`, or `PollingComponent` updates running at sub-`loop_interval_` cadences (common on busy ESP32 builds), every component's `loop()` ran at roughly double the documented rate. As of 2026.4.0, components run at the configured `loop_interval_` exactly, and `App.set_loop_interval()` actually saves power. See ["Choosing Between loop() and the Scheduler"](#choosing-between-loop-and-the-scheduler) below for what this means for periodic work.
 
 On platforms with socket select support (ESP32, Host, and LibreTiny-based chips like BK72xx/RTL87xx), the loop also wakes up immediately when there is new data on monitored sockets (such as API connections and OTA updates), ensuring low-latency network communication without polling. ESP8266 and RP2040 platforms use a simpler TCP implementation without select support.
 
@@ -185,7 +185,7 @@ Components track their loop state using internal flags:
 With the main loop running at the configured `loop_interval_` (default 16 ms / ~62 Hz):
 
 - An idle component with an empty `loop()` still consumes CPU cycles each tick
-- 10 disabled components save ~37,000 function calls per minute (default cadence)
+- 10 disabled components save ~37,500 function calls per minute (default cadence)
 - Critical for ESP8266/ESP32 devices with limited CPU resources, and for power-managed configurations using `App.set_loop_interval()`
 
 #### Thread Safety
@@ -281,7 +281,7 @@ Each main-loop tick has two phases. **Phase A** runs every tick (drains wake not
 
 ### RAM cost
 
-`set_timeout`, `set_interval`, and `defer` store callbacks in `std::function`, which has an ~8-byte small-buffer optimization. **Captures larger than 8 bytes spill to heap allocation**, fragmenting the heap over time. Each registration adds its own `std::function` — three timers means three allocations.
+`set_timeout`, `set_interval`, and `defer` store callbacks in `std::function`. With libstdc++ on 32-bit MCUs (the configuration ESPHome targets), the small-buffer optimization holds **~8 bytes** of capture inline; **larger captures spill to heap allocation**, fragmenting the heap over time. Other standard libraries differ, but ESPHome builds are GCC + libstdc++ in practice. Each registration adds its own `std::function` — three timers means three callback objects.
 
 ```cpp
 this->set_interval(1000, [this]() { this->tick_(); });               // SBO-safe (one pointer)

--- a/docs/architecture/components/advanced.md
+++ b/docs/architecture/components/advanced.md
@@ -6,8 +6,8 @@ This section covers advanced component development topics in ESPHome. These feat
 
 ESPHome's main loop runs at the configured `loop_interval_` (default ~16 ms, ~62.5 Hz / ~3750 component-phase calls per minute), calling each registered component's `loop()` method. This is fast enough to feel responsive but still wastes CPU cycles for components that don't need continuous updates. The loop control API allows components to dynamically enable or disable their participation in the main loop.
 
-!!! note "Cadence change in 2026.4.0"
-    Before [PR #15792](https://github.com/esphome/esphome/pull/15792), `loop()` could be emergently pulled forward to roughly double the configured rate when the scheduler had a timer due sooner than `loop_interval_/2`. Configs without scheduler activity weren't affected, but on devices with `set_interval`, `set_timeout`, or `PollingComponent` updates running at sub-`loop_interval_` cadences (common on busy ESP32 builds), every component's `loop()` ran at roughly double the documented rate. As of 2026.4.0, components run at the configured `loop_interval_` exactly, and `App.set_loop_interval()` actually saves power. See ["Choosing Between loop() and the Scheduler"](#choosing-between-loop-and-the-scheduler) below for what this means for periodic work.
+!!! note "Cadence change in 2026.5.0"
+    Before [PR #15792](https://github.com/esphome/esphome/pull/15792), `loop()` could be emergently pulled forward to roughly double the configured rate when the scheduler had a timer due sooner than `loop_interval_/2`. Configs without scheduler activity weren't affected, but on devices with `set_interval`, `set_timeout`, or `PollingComponent` updates running at sub-`loop_interval_` cadences (common on busy ESP32 builds), every component's `loop()` ran at roughly double the documented rate. As of 2026.5.0, components run at the configured `loop_interval_` exactly, and `App.set_loop_interval()` actually saves power. See ["Choosing Between loop() and the Scheduler"](#choosing-between-loop-and-the-scheduler) below for what this means for periodic work.
 
 On platforms with socket select support (ESP32, Host, and LibreTiny-based chips like BK72xx/RTL87xx), the loop also wakes up immediately when there is new data on monitored sockets (such as API connections and OTA updates), ensuring low-latency network communication without polling. ESP8266 and RP2040 platforms use a simpler TCP implementation without select support.
 
@@ -182,7 +182,7 @@ Components track their loop state using internal flags:
 
 #### Performance Considerations
 
-With the main loop running at the configured `loop_interval_` (default 16 ms / ~62 Hz):
+With the main loop running at the configured `loop_interval_` (default 16 ms / ~62.5 Hz):
 
 - An idle component with an empty `loop()` still consumes CPU cycles each tick
 - 10 disabled components save ~37,500 function calls per minute (default cadence)
@@ -260,7 +260,7 @@ To debug loop control issues:
 
 ## Choosing Between loop() and the Scheduler
 
-ESPHome offers several primitives for periodic or deferred work. Since the main-loop cadence fix in 2026.4.0 ([PR #15792](https://github.com/esphome/esphome/pull/15792)), the tradeoffs have shifted enough that some older patterns are now pessimizations.
+ESPHome offers several primitives for periodic or deferred work. Since the main-loop cadence fix in 2026.5.0 ([PR #15792](https://github.com/esphome/esphome/pull/15792)), the tradeoffs have shifted enough that some older patterns are now pessimizations.
 
 ### Quick rule of thumb
 

--- a/docs/architecture/components/advanced.md
+++ b/docs/architecture/components/advanced.md
@@ -290,7 +290,7 @@ this->set_interval(1000, [this, addr, name]() { this->ping_(...); }); // heap-al
 
 ### Other primitives
 
-- **`set_interval` still wins** for slow cadences (≥ 30 s) and likely wins for anything > 500 ms; also when many items share one cadence or when you need named cancellation.
+- **`set_interval` still wins** for intervals ≥ 500 ms, when many items share one cadence, or when you need named cancellation.
 - **`set_timeout`** — one-shots and self-rescheduling timers with variable delays. Don't chain it as a hand-rolled `set_interval`.
 - **`defer`** — run-once on the next main-loop iteration; use it to break recursion or escape interrupt context, not as a task queue.
 

--- a/docs/architecture/components/advanced.md
+++ b/docs/architecture/components/advanced.md
@@ -290,7 +290,7 @@ this->set_interval(1000, [this, addr, name]() { this->ping_(...); }); // heap-al
 
 ### Other primitives
 
-- **`set_interval` still wins** for slow cadences (≥ 30 s), shared cadence across many items, or when you need named cancellation.
+- **`set_interval` still wins** for slow cadences (≥ 30 s) and likely wins for anything > 500 ms; also when many items share one cadence or when you need named cancellation.
 - **`set_timeout`** — one-shots and self-rescheduling timers with variable delays. Don't chain it as a hand-rolled `set_interval`.
 - **`defer`** — run-once on the next main-loop iteration; use it to break recursion or escape interrupt context, not as a task queue.
 

--- a/docs/architecture/components/advanced.md
+++ b/docs/architecture/components/advanced.md
@@ -4,7 +4,10 @@ This section covers advanced component development topics in ESPHome. These feat
 
 ## Component Loop Control
 
-ESPHome's main loop runs approximately every 7ms (~7000 times per minute), calling each component's `loop()` method. This high frequency ensures responsive behavior but can waste CPU cycles for components that don't need continuous updates. The loop control API allows components to dynamically enable or disable their participation in the main loop.
+ESPHome's main loop runs at the configured `loop_interval_` (default ~16 ms, ~62 Hz / ~3720 component-phase calls per minute), calling each registered component's `loop()` method. This is fast enough to feel responsive but still wastes CPU cycles for components that don't need continuous updates. The loop control API allows components to dynamically enable or disable their participation in the main loop.
+
+!!! note "Cadence change in 2026.4.0"
+    Before [PR #15792](https://github.com/esphome/esphome/pull/15792), `loop()` could be emergently pulled forward to ~128 Hz (~2× the configured rate) when the scheduler had a timer due sooner than `loop_interval_/2`. Configs without scheduler activity weren't affected, but on devices with `set_interval`, `set_timeout`, or `PollingComponent` updates running at sub-`loop_interval_` cadences (common on busy ESP32 builds), every component's `loop()` ran at roughly double the documented rate. As of 2026.4.0, components run at the configured `loop_interval_` exactly, and `App.set_loop_interval()` actually saves power. See ["Choosing Between loop() and the Scheduler"](#choosing-between-loop-and-the-scheduler) below for what this means for periodic work.
 
 On platforms with socket select support (ESP32, Host, and LibreTiny-based chips like BK72xx/RTL87xx), the loop also wakes up immediately when there is new data on monitored sockets (such as API connections and OTA updates), ensuring low-latency network communication without polling. ESP8266 and RP2040 platforms use a simpler TCP implementation without select support.
 
@@ -179,11 +182,11 @@ Components track their loop state using internal flags:
 
 #### Performance Considerations
 
-With the main loop running every ~7ms:
+With the main loop running at the configured `loop_interval_` (default 16 ms / ~62 Hz):
 
-- An idle component with an empty `loop()` still consumes CPU cycles
-- 10 disabled components save ~70,000 function calls per minute
-- Critical for ESP8266/ESP32 devices with limited CPU resources
+- An idle component with an empty `loop()` still consumes CPU cycles each tick
+- 10 disabled components save ~37,000 function calls per minute (default cadence)
+- Critical for ESP8266/ESP32 devices with limited CPU resources, and for power-managed configurations using `App.set_loop_interval()`
 
 #### Thread Safety
 
@@ -254,6 +257,42 @@ To debug loop control issues:
    ```
 
 3. Use the Logger component's async support as a reference implementation
+
+## Choosing Between loop() and the Scheduler
+
+ESPHome offers several primitives for periodic or deferred work. Since the main-loop cadence fix in 2026.4.0 ([PR #15792](https://github.com/esphome/esphome/pull/15792)), the tradeoffs have shifted enough that some older patterns are now pessimizations.
+
+### Quick rule of thumb
+
+| Cadence / shape | Recommended primitive |
+|---|---|
+| Sub-`loop_interval_` (`< 16 ms`) wakes | `HighFrequencyLoopRequester` |
+| Periodic, **interval < 250 ms** | `loop()` + `App.get_loop_component_start_time()` gate |
+| Periodic, **250–500 ms** | Either; `loop()` usually still cheaper |
+| Periodic, **≥ 500 ms** | `set_interval` |
+| One-shot or rare reschedule | `set_timeout` |
+| Run-once-on-next-loop | `defer` |
+
+Crossover depends on how cheap your `loop()` "nothing to do" path is and whether the timer interval would force extra Phase A wakes. Use `App.get_loop_component_start_time()` rather than `millis()` — it's cached per tick.
+
+### Why `loop()` wins for sub-second work
+
+Each main-loop tick has two phases. **Phase A** runs every tick (drains wake notifications, runs due scheduler entries, feeds the watchdog). **Phase B** runs the component list only when `loop_interval_` elapsed, `HighFrequencyLoopRequester` is active, or a `wake_loop_*` raised the flag. A `set_interval(N)` with `N` smaller than (or unaligned with) `loop_interval_` forces extra Phase A wakes that each pay scheduler-dispatch + WDT-feed cost — often more than the work itself.
+
+### RAM cost
+
+`set_timeout`, `set_interval`, and `defer` store callbacks in `std::function`, which has an ~8-byte small-buffer optimization. **Captures larger than 8 bytes spill to heap allocation**, fragmenting the heap over time. A `loop()` method needs no allocation and no capture — `this` is already available.
+
+```cpp
+this->set_interval(1000, [this]() { this->tick_(); });               // SBO-safe (one pointer)
+this->set_interval(1000, [this, addr, name]() { this->ping_(...); }); // heap-allocated (> 8 bytes)
+```
+
+### Other primitives
+
+- **`set_interval` still wins** for slow cadences (≥ 30 s), shared cadence across many items, or when you need named cancellation.
+- **`set_timeout`** — one-shots and self-rescheduling timers with variable delays. Don't chain it as a hand-rolled `set_interval`.
+- **`defer`** — run-once on the next main-loop iteration; use it to break recursion or escape interrupt context, not as a task queue.
 
 ## Waking the Main Loop from Background Threads
 


### PR DESCRIPTION
# Document loop() vs scheduler tradeoffs after main-loop cadence fix

## What does this implement/fix?

Updates `docs/architecture/components/advanced.md` to reflect the main-loop cadence change in 2026.5.0 ([PR #15792](https://github.com/esphome/esphome/pull/15792)) and document the resulting guidance on choosing between `loop()` and the scheduler primitives.

### Changes

1. **Corrected the cadence description** in "Component Loop Control" — replaced the inaccurate "~7 ms / ~7000 calls per minute" with the actual configured `loop_interval_` (default 16 ms / ~62 Hz / ~3720 calls per minute).
2. **Added a `note` admonition** explaining that pre-2026.5.0 the loop was emergently pulled forward to ~128 Hz when scheduler timers were active — not universal, but common on busy ESP32 builds. As of 2026.5.0, components run at the configured `loop_interval_` exactly.
3. **Updated the "Performance Considerations" math** from "70,000 calls/min for 10 disabled components" to "~37,000 calls/min" at the actual default cadence.
4. **New section "Choosing Between loop() and the Scheduler"** — placed between Component Loop Control and Waking the Main Loop. Includes:
   - Decision table:
     - `< 250 ms` → `loop()` + `App.get_loop_component_start_time()` gate
     - `250–500 ms` → either; `loop()` usually still cheaper
     - `≥ 500 ms` → `set_interval`
     - One-shot → `set_timeout`; next-loop → `defer`; sub-tick wakes → `HighFrequencyLoopRequester`
   - Phase A / Phase B explanation of *why* sub-`loop_interval_` timers force extra wakes.
   - `std::function` SBO 8-byte capture warning with a code example.
   - Notes on when `set_interval` still wins (intervals ≥ 500 ms, shared cadence, named cancellation) and the appropriate use of `set_timeout` / `defer`.

### Motivation

The bluetooth_proxy revert in [PR #15992](https://github.com/esphome/esphome/pull/15992) demonstrated that converting a `loop()` body to a sub-`loop_interval_` `set_interval` is now a pessimization, because the timer forces extra Phase A wakes that don't align with the natural Phase B cadence. Measured impact on ESP32-IDF over 60 s:

| Metric | `set_interval(100ms)` | `loop()` gate |
|---|---|---|
| main_loop iterations | 4305 | 3719 (−13.6 %) |
| scheduler dispatch | 41.8 ms | 21.0 ms (−50 %) |
| watchdog feed | 7.2 ms | 3.3 ms (−54 %) |
| total main-loop overhead | 68.0 ms | 48.5 ms (−29 %) |

The 250 ms / 500 ms thresholds in the new guidance come from this measurement plus follow-up discussion: below ~250 ms intervals, `loop()` is consistently cheaper; at 500 ms and above, `set_interval` is generally cheaper because the per-tick `loop()` dispatch overhead × call count exceeds the scheduler's per-fire cost.

### Related

- esphome/esphome#15792 — main-loop cadence decoupling
- esphome/esphome#15992 — bluetooth_proxy revert (the worked example that drove this guidance)
- esphome/esphome#15347 — original migration that became a pessimization after #15792
