### PR TITLE
Clarify C++ deprecation order: migrate in-tree callers before marking deprecated

### DIFF
--- a/docs/contributing/code.md
+++ b/docs/contributing/code.md
@@ -467,7 +467,7 @@ correctly. Breaking changes must be:
 
 When you need to make a C++ breaking change:
 
-1. **Migrate all in-codebase usage to the new API first.** Update every caller in the ESPHome repository (core,
+1. **Migrate all in-tree usage to the new API first.** Update every caller in the ESPHome repository (core,
    components, tests) to use the new pattern before any deprecation warning is added. Marking something deprecated
    while internal callers still use it produces a stream of warnings from our own codebase, which drowns out the
    warnings users actually need to see, churns across dev cycles, and erodes the signal that deprecation warnings
@@ -485,7 +485,7 @@ When you need to make a C++ breaking change:
     releases and the cleanup tends to stall.
 
     This rule applies to in-tree code only. External components and user configurations are exactly who the
-    deprecation warning is for, and the 6 month compatibility window gives them time to react.
+    deprecation warning is for, and the 6-month compatibility window gives them time to react.
 
 !!!note "C++ Compatibility Window"
     ESPHome aims to maintain backward compatibility for 6 months when possible. However, some C++ breaking changes

--- a/docs/contributing/code.md
+++ b/docs/contributing/code.md
@@ -467,11 +467,25 @@ correctly. Breaking changes must be:
 
 When you need to make a C++ breaking change:
 
-1. **Add a deprecation warning** using compile-time warnings or runtime logs (when possible—see compatibility window note)
-2. **Maintain the old behavior** alongside the new for 6 months when possible (note: for C++ changes, maintaining
-   backward compatibility is not always possible, especially for signature changes or refactorings)
-3. **Document the migration path** in the PR description (which generates release notes) and code comments
-4. **Update all internal usage** to use the new API
+1. **Migrate all in-codebase usage to the new API first.** Update every caller in the ESPHome repository (core,
+   components, tests) to use the new pattern before any deprecation warning is added. Marking something deprecated
+   while internal callers still use it produces a stream of warnings from our own codebase, which drowns out the
+   warnings users actually need to see, churns across dev cycles, and erodes the signal that deprecation warnings
+   are supposed to carry.
+2. **Add the deprecation warning** using compile-time warnings or runtime logs (when possible; see compatibility
+   window note), only after step 1 is complete and the codebase is clean.
+3. **Maintain the old behavior** alongside the new for 6 months when possible (note: for C++ changes, maintaining
+   backward compatibility is not always possible, especially for signature changes or refactorings).
+4. **Document the migration path** in the PR description (which generates release notes) and code comments.
+
+!!!note "Should I mark something deprecated in one PR and migrate callers later?"
+    No. Migrate every in-tree caller to the new API in the same PR, or in PRs that land before the deprecation PR.
+    The deprecation warning should not fire on any code we ship. This is especially important when a migration may
+    span multiple dev cycles; if the codebase is left to migrate itself gradually, the warnings linger across
+    releases and the cleanup tends to stall.
+
+    This rule applies to in-tree code only. External components and user configurations are exactly who the
+    deprecation warning is for, and the 6 month compatibility window gives them time to react.
 
 !!!note "C++ Compatibility Window"
     ESPHome aims to maintain backward compatibility for 6 months when possible. However, some C++ breaking changes


### PR DESCRIPTION
Clarifies the C++ deprecation process to answer a question that came up in `#devs`: should you mark something deprecated in one PR and migrate the rest of the ESPHome codebase to the new pattern in follow-up PRs?

The answer is no. The deprecation warning should not fire on any code we ship. If callers in core, components, or tests still use the old pattern when the deprecation lands, every build emits warnings from our own code, which drowns out the warnings external components and user configs actually need to see and tends to linger across multiple dev cycles before anyone cleans it up.

Reorders the numbered steps so "migrate all in-tree usage" is step 1 rather than step 4, and adds a callout note explicitly addressing the question. The rule applies to in-tree code only; external components and user configs are who the deprecation warning is for, and the 6 month compatibility window gives them time to react.