### PR TITLE
Document the visibility schema kwarg + cascade rule for visual editors

### DIFF
--- a/docs/contributing/code.md
+++ b/docs/contributing/code.md
@@ -533,7 +533,7 @@ ignores it at runtime — it just flows through the schema dump
 |---|---|---|
 | _(unset, the default)_ | Render the field on the editor's main form. | The field is normal config — the user genuinely wants to see it. |
 | `cv.Visibility.ADVANCED` | Render the field, but tuck it under the editor's "advanced settings" disclosure. | The default is right for ~all users; power users can still tune the YAML directly without crowding the form. |
-| `cv.Visibility.YAML_ONLY` | Never render the field in a visual editor. | The knob is dangerous to expose in a UI even as advanced — a casual click could break boot or otherwise mis-configure the component. |
+| `cv.Visibility.YAML_ONLY` | Never render the field in a visual editor. | The knob is dangerous to expose in a UI even as advanced — a casual click could break boot or otherwise misconfigure the component. |
 
 The values are points along a single axis of strictness:
 `YAML_ONLY` > `ADVANCED` > _unset_. The single-axis shape encodes "yaml-only is strictly stronger
@@ -543,7 +543,7 @@ contradictory state.
 !!!example "Visibility kwarg in practice"
     ```python
     # Field belongs on the editor's "advanced settings" section
-    cv.Optional(CONF_FOO, default="42", visibility=cv.Visibility.ADVANCED): cv.int_
+    cv.Optional(CONF_FOO, default=42, visibility=cv.Visibility.ADVANCED): cv.int_
 
     # Field never shows in a visual editor — YAML escape hatch
     # stays available for the rare power-user override.
@@ -562,7 +562,7 @@ adding an opt-in kwarg to the helper so callers stay declarative — for example
 
 ##### Cascading
 
-A stricter parent forces every descendant at-least as strict. Schema consumers (the device-builder
+A stricter parent forces every descendant at least as strict. Schema consumers (the device-builder
 catalog generator and similar) walk the parent chain when computing the *effective* visibility for
 each field — a child can only ever be **stricter** than its parent, never more visible:
 

--- a/docs/contributing/code.md
+++ b/docs/contributing/code.md
@@ -519,6 +519,60 @@ API. This includes:
 - **Configuration structure**: Nesting requirements, required vs optional keys
 - **Platform names**: The names used to reference components (e.g., `sensor.dht`, `switch.gpio`)
 
+#### Schema-driven UI hints (`advanced` / `yaml_only`)
+
+Some configuration keys are valid YAML but a poor fit for a visual editor (the dashboard's
+add-component form, the section editor, third-party schema-driven tooling, …). ESPHome's
+`cv.Optional` and `cv.Required` accept two opt-in keyword arguments that let the field's author
+decide how editors should render it. Both flags are **purely advisory** — they don't affect
+validation in any way; ESPHome itself ignores them at runtime — they just flow through the schema
+dump (`script/build_language_schema.py`) so downstream consumers can act on them.
+
+| Kwarg | Semantics | Use when |
+|---|---|---|
+| `advanced=True` | Render the field, but tuck it under the editor's "advanced settings" disclosure. | The default is right for ~all users; power users can still tune the YAML directly without crowding the form. |
+| `yaml_only=True` | Never render the field in a visual editor. | The knob is dangerous to expose in a UI even as advanced — a casual click could break boot or otherwise mis-configure the component. |
+
+`yaml_only` is the stronger signal — a sensible consumer treats `yaml_only` as "hide" regardless of
+the `advanced` value. Setting both is fine; the contract is "either is sufficient to skip the main
+form".
+
+!!!example "UI hint kwargs in practice"
+    ```python
+    # Field belongs on the editor's "advanced settings" section
+    cv.Optional(CONF_FOO, default="42", advanced=True): cv.int_
+
+    # Field never shows in a visual editor — YAML escape hatch
+    # stays available for the rare power-user override.
+    cv.Optional(CONF_BAR, yaml_only=True): cv.string
+
+    # Required works the same way
+    cv.Required(CONF_BAZ, advanced=True): cv.boolean
+    ```
+
+For helpers that produce schemas behind a function call (like `cv.polling_component_schema`), prefer
+adding an opt-in kwarg to the helper so callers stay declarative — for example,
+`polling_component_schema` exposes `advanced_update_interval=True` so a time-platform call site can
+opt the inherited `update_interval` into the advanced section without affecting sensors and other
+polling components.
+
+When in doubt:
+
+- Don't set either flag. The default (no flag) keeps the field on the main form, which is the right
+  answer for the long tail of normal config keys.
+- Reach for `advanced=True` when the field is *valid* but you'd be answering the user's question
+  with a question if you led with it ("How often should I sync time?" — they don't know, the default
+  is fine).
+- Reach for `yaml_only=True` only when surfacing the field in a UI is actively unsafe.
+  `setup_priority` is the canonical example: it exists on every component (via
+  `core.COMPONENT_SCHEMA`'s extends), the default is correct in essentially every case, and a visual
+  editor putting "Setup Priority" on every component's Advanced section is a foot-gun even there.
+
+Adding a flag to an existing field is **not** a breaking change for YAML users — the YAML still
+validates the same way. It can be a meaningful change for a visual editor, though, so coordinate
+with downstream catalog consumers (e.g. esphome/device-builder) before flipping a previously-shown
+field to `yaml_only=True`.
+
 #### Python Functions and Classes
 
 Unlike C++, most Python code in ESPHome is **internal implementation** unless explicitly documented:

--- a/docs/contributing/code.md
+++ b/docs/contributing/code.md
@@ -519,59 +519,80 @@ API. This includes:
 - **Configuration structure**: Nesting requirements, required vs optional keys
 - **Platform names**: The names used to reference components (e.g., `sensor.dht`, `switch.gpio`)
 
-#### Schema-driven UI hints (`advanced` / `yaml_only`)
+#### Schema-driven UI hints (`visibility`)
 
 Some configuration keys are valid YAML but a poor fit for a visual editor (the dashboard's
 add-component form, the section editor, third-party schema-driven tooling, …). ESPHome's
-`cv.Optional` and `cv.Required` accept two opt-in keyword arguments that let the field's author
-decide how editors should render it. Both flags are **purely advisory** — they don't affect
-validation in any way; ESPHome itself ignores them at runtime — they just flow through the schema
-dump (`script/build_language_schema.py`) so downstream consumers can act on them.
+`cv.Optional` and `cv.Required` accept a single opt-in `visibility=` keyword argument backed by
+the `cv.Visibility` `StrEnum` that lets the field's author decide how editors should render it.
+The kwarg is **purely advisory** — it doesn't affect validation in any way; ESPHome itself
+ignores it at runtime — it just flows through the schema dump
+(`script/build_language_schema.py`) so downstream consumers can act on it.
 
-| Kwarg | Semantics | Use when |
+| Value | Semantics | Use when |
 |---|---|---|
-| `advanced=True` | Render the field, but tuck it under the editor's "advanced settings" disclosure. | The default is right for ~all users; power users can still tune the YAML directly without crowding the form. |
-| `yaml_only=True` | Never render the field in a visual editor. | The knob is dangerous to expose in a UI even as advanced — a casual click could break boot or otherwise mis-configure the component. |
+| _(unset, the default)_ | Render the field on the editor's main form. | The field is normal config — the user genuinely wants to see it. |
+| `cv.Visibility.ADVANCED` | Render the field, but tuck it under the editor's "advanced settings" disclosure. | The default is right for ~all users; power users can still tune the YAML directly without crowding the form. |
+| `cv.Visibility.YAML_ONLY` | Never render the field in a visual editor. | The knob is dangerous to expose in a UI even as advanced — a casual click could break boot or otherwise mis-configure the component. |
 
-`yaml_only` is the stronger signal — a sensible consumer treats `yaml_only` as "hide" regardless of
-the `advanced` value. Setting both is fine; the contract is "either is sufficient to skip the main
-form".
+The values are points along a single axis of strictness:
+`YAML_ONLY` > `ADVANCED` > _unset_. The single-axis shape encodes "yaml-only is strictly stronger
+than advanced" at the type level — there's no way to ask for both at once, and no way to set a
+contradictory state.
 
-!!!example "UI hint kwargs in practice"
+!!!example "Visibility kwarg in practice"
     ```python
     # Field belongs on the editor's "advanced settings" section
-    cv.Optional(CONF_FOO, default="42", advanced=True): cv.int_
+    cv.Optional(CONF_FOO, default="42", visibility=cv.Visibility.ADVANCED): cv.int_
 
     # Field never shows in a visual editor — YAML escape hatch
     # stays available for the rare power-user override.
-    cv.Optional(CONF_BAR, yaml_only=True): cv.string
+    cv.Optional(CONF_BAR, visibility=cv.Visibility.YAML_ONLY): cv.string
 
-    # Required works the same way
-    cv.Required(CONF_BAZ, advanced=True): cv.boolean
+    # Required accepts the same kwarg for symmetry. Use it
+    # cautiously: hiding a Required field behind an advanced
+    # disclosure can let users submit with the field unfilled.
+    cv.Required(CONF_BAZ, visibility=cv.Visibility.ADVANCED): cv.boolean
     ```
 
 For helpers that produce schemas behind a function call (like `cv.polling_component_schema`), prefer
 adding an opt-in kwarg to the helper so callers stay declarative — for example,
-`polling_component_schema` exposes `advanced_update_interval=True` so a time-platform call site can
-opt the inherited `update_interval` into the advanced section without affecting sensors and other
-polling components.
+`polling_component_schema` exposes `visibility=` so a time-platform call site can opt the inherited
+`update_interval` into the advanced section without affecting sensors and other polling components.
+
+##### Cascading
+
+A stricter parent forces every descendant at-least as strict. Schema consumers (the device-builder
+catalog generator and similar) walk the parent chain when computing the *effective* visibility for
+each field — a child can only ever be **stricter** than its parent, never more visible:
+
+- A NESTED block marked `ADVANCED` puts every inner field under the same disclosure. An inner field
+  with no `visibility` setting still ends up in the "advanced" section because the parent is.
+- A NESTED block marked `YAML_ONLY` hides every descendant — otherwise the editor would render an
+  unrooted control with no surrounding context to interpret it.
+- An inner field marked `YAML_ONLY` under an `ADVANCED` parent stays hidden — the strictness
+  ordering is monotonic.
+
+The schema marker itself is per-field as the author wrote it; the cascade is a consumer concern,
+not a mutation of the schema. This keeps the dump faithful to what's at each call site.
 
 When in doubt:
 
-- Don't set either flag. The default (no flag) keeps the field on the main form, which is the right
-  answer for the long tail of normal config keys.
-- Reach for `advanced=True` when the field is *valid* but you'd be answering the user's question
-  with a question if you led with it ("How often should I sync time?" — they don't know, the default
-  is fine).
-- Reach for `yaml_only=True` only when surfacing the field in a UI is actively unsafe.
+- Don't set `visibility`. The default keeps the field on the main form, which is the right answer
+  for the long tail of normal config keys.
+- Reach for `Visibility.ADVANCED` when the field is *valid* but you'd be answering the user's
+  question with a question if you led with it ("How often should I sync time?" — they don't know,
+  the default is fine).
+- Reach for `Visibility.YAML_ONLY` only when surfacing the field in a UI is actively unsafe.
   `setup_priority` is the canonical example: it exists on every component (via
-  `core.COMPONENT_SCHEMA`'s extends), the default is correct in essentially every case, and a visual
-  editor putting "Setup Priority" on every component's Advanced section is a foot-gun even there.
+  `core.COMPONENT_SCHEMA`'s extends), the default is correct in essentially every case, and a
+  visual editor putting "Setup Priority" on every component's Advanced section is a foot-gun even
+  there.
 
-Adding a flag to an existing field is **not** a breaking change for YAML users — the YAML still
-validates the same way. It can be a meaningful change for a visual editor, though, so coordinate
-with downstream catalog consumers (e.g. esphome/device-builder) before flipping a previously-shown
-field to `yaml_only=True`.
+Adding a `visibility` value to an existing field is **not** a breaking change for YAML users — the
+YAML still validates the same way. It can be a meaningful change for a visual editor, though, so
+coordinate with downstream catalog consumers (e.g. esphome/device-builder) before flipping a
+previously-shown field to `Visibility.YAML_ONLY`.
 
 #### Python Functions and Classes
 


### PR DESCRIPTION
# What does this implement/fix?

Documents the new `cv.Visibility` `StrEnum` and `visibility=`
kwarg on `cv.Optional` / `cv.Required` introduced in
esphome/esphome#16267.

The kwarg is a UI hint consumed by schema-driven editors (the
device-builder dashboard catalog, third-party tools); it doesn't
affect YAML validation. This PR adds a `#### Schema-driven UI
hints (visibility)` subsection under the existing "Configuration
Schema" / public-Python-API section in
`docs/contributing/code.md` covering:

- The three values (unset / `ADVANCED` / `YAML_ONLY`) and when
  to reach for each.
- The single-axis strictness ordering (`YAML_ONLY` > `ADVANCED`
  > unset) — encoded in the type so contradictory states can't
  be expressed.
- Real-world examples (`setup_priority` →
  `Visibility.YAML_ONLY`, time-platform `update_interval` →
  `Visibility.ADVANCED`).
- The helper-kwarg pattern for schemas that wrap a `cv.Optional`
  inside a function call (e.g. `polling_component_schema`'s new
  `visibility=` parameter).
- A new `##### Cascading` subsection explaining the consumer-side
  rule: a stricter parent forces every descendant at-least as
  strict. The schema marker stays per-field as the author wrote
  it; the cascade is computed by consumers when they walk the
  tree.
- A note that adding `visibility` isn't a YAML-side breaking
  change but does need coordination with catalog consumers when
  flipping a previously-shown field to `Visibility.YAML_ONLY`.

**Related issue or feature (if applicable):**

- Pairs with esphome/esphome#16267
- Companion catalog-consumer PR: esphome/device-builder#350
- Companion frontend docs PR: esphome/device-builder-frontend#182
