### PR TITLE
Update references to renamed esphome.io repo (formerly esphome-docs)

### DIFF
--- a/docs/contributing/code.md
+++ b/docs/contributing/code.md
@@ -776,7 +776,7 @@ When you need to make a Python breaking change:
 1. **Add a deprecation warning** during configuration validation
 2. **Maintain backward compatibility** for 6 months when possible
 3. **Document the migration path** clearly in warnings and the PR description (which generates release notes)
-4. **Update all examples** in esphome-docs to use the new configuration format
+4. **Update all examples** in esphome.io to use the new configuration format
 
 !!!note "Python Compatibility Window"
     ESPHome aims to maintain backward compatibility for Python/configuration changes for 6 months. Python changes
@@ -902,7 +902,7 @@ Before making a breaking change (C++ or Python), ensure you:
 - [ ] Documented the migration path clearly in the PR description
 - [ ] Included migration instructions in the PR description (they will be used to generate release notes)
 - [ ] Updated all internal usage to the new API
-- [ ] Updated esphome-docs examples and documentation
+- [ ] Updated esphome.io examples and documentation
 - [ ] Tested that existing configurations still work (for deprecations)
 - [ ] Considered the impact on external components
 - [ ] Written a blog post (if the change affects core functions, core entity classes, or represents a significant architectural change)

--- a/docs/contributing/docs.md
+++ b/docs/contributing/docs.md
@@ -1,6 +1,6 @@
 ![logo-docs](/images/logo-docs.svg)
 
-# Contributing to `esphome-docs`
+# Contributing to `esphome.io`
 
 Our documentation can always be improved. We rely on contributions from our users to do so. If you notice an issue (for
 example, spelling/grammar mistakes) or if you want to share your awesome new setup, we encourage you to submit a pull
@@ -26,7 +26,7 @@ use components. If you're not familiar with Markdown, see [Markdown syntax](#mar
     - If you need an image for your new component/platform, use our
       [component image generator](https://github.com/esphome/component-image-generator). You can run this in a
       container locally to generate the image or summon our bot to do so by adding a comment to your PR in the
-      `esphome-docs` repository: `@esphomebot generate image MyNewComponent`
+      `esphome.io` repository: `@esphomebot generate image MyNewComponent`
 - If a component/platform is used exclusively/primarily on a single specific board (perhaps with dedicated pin
   numbers), a complete configuration for the component/platform on that specific board may be included as an example
   _at the end of the document._ This example must be clearly identified as being for that specific hardware and it may
@@ -36,7 +36,7 @@ use components. If you're not familiar with Markdown, see [Markdown syntax](#mar
   [https://tinypng.com](https://tinypng.com).
 - When using highly accurate, domain-specific terminology, be sure that it does not interfere with a new user's ability
   to understand the content.
-- Be sure to target the correct **base branch** of the `esphome-docs` repository:
+- Be sure to target the correct **base branch** of the `esphome.io` repository:
     - **Fixes/improvements** for documentation must target the `current` branch.
     - **New features** must target the `next` branch.
 - **Create new branches in your fork** for each pull request; to avoid confusion (and other potential issues), do not
@@ -99,7 +99,7 @@ errors. If, however, more errors are discovered, simply repeat the process above
 ## Build
 
 To check your documentation changes locally, you first need [Node.js](https://nodejs.org/) (v18 or later). Then, from
-the root of the `esphome-docs` repository:
+the root of the `esphome.io` repository:
 
 ```bash
 npm install
@@ -380,10 +380,10 @@ convert -sampling-factor 4:2:0 -strip -interlace Plane -quality 80% -resize 300x
 
 ### Project structure
 
-For reference, the `esphome-docs` repository is organized as follows:
+For reference, the `esphome.io` repository is organized as follows:
 
 ```text
-esphome-docs/
+esphome.io/
 ├── src/
 │   ├── assets/                      # Static assets (logos, etc.)
 │   ├── components/                  # Astro components (Figure, APIRef, etc.)

--- a/docs/contributing/submitting-your-work.md
+++ b/docs/contributing/submitting-your-work.md
@@ -244,7 +244,7 @@ git fetch upstream dev
 git rebase upstream/dev
 ```
 
-Note that you can use this procedure for other branches, too, such as `next` or `current` from `esphome-docs`.
+Note that you can use this procedure for other branches, too, such as `next` or `current` from `esphome.io`.
 
 ### Do not force-push!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Start developing your own components for ESPHome!
 All project code and documentation is hosted on [GitHub](https://github.com):
 
 - [ESPHome](https://github.com/esphome/esphome)
-- [ESPHome-Docs](https://github.com/esphome/esphome-docs)
+- [ESPHome-Docs](https://github.com/esphome/esphome.io)
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Start developing your own components for ESPHome!
 All project code and documentation is hosted on [GitHub](https://github.com):
 
 - [ESPHome](https://github.com/esphome/esphome)
-- [ESPHome-Docs](https://github.com/esphome/esphome.io)
+- [esphome.io](https://github.com/esphome/esphome.io)
 
 ---
 


### PR DESCRIPTION
## Summary

The `esphome-docs` GitHub repository has been renamed to `esphome.io`. This updates documentation links, headings, prose references, and the example directory tree in the developer docs so contributors are pointed at the correct repository.

Touched files:

- `docs/index.md` — GitHub URL on the landing page
- `docs/contributing/docs.md` — heading, esphomebot example, base-branch note, build root, project structure tree
- `docs/contributing/submitting-your-work.md` — branch reference
- `docs/contributing/code.md` — breaking-change checklist references