### PR TITLE
Document marking leaf component and automation classes as final

### DIFF
--- a/docs/architecture/components/automations.md
+++ b/docs/architecture/components/automations.md
@@ -8,6 +8,10 @@ ESPHome automations consist of three building blocks:
 
 This page covers how to implement all three in a component. For a minimal working example, see the [empty_automation starter component](https://github.com/esphome/starter-components/tree/main/components/empty_automation).
 
+!!! note "Mark primitives `final`"
+
+    The `Action`, `Trigger`, and `Condition` subclasses shown below are leaf classes — nothing in ESPHome derives from them — so they are marked `final`. See [Marking leaf classes as `final`](/contributing/code/#marking-leaf-classes-as-final) for the rationale.
+
 !!! note
 
     All Python examples below assume the standard ESPHome imports are present: `esphome.codegen as cg`, `esphome.config_validation as cv`, relevant constants from `esphome.const`, and typing imports (`ConfigType` from `esphome.types`, `MockObj` from `esphome.cpp_generator`, `TemplateArgsType` from `esphome.automation`).
@@ -171,7 +175,7 @@ async def to_code(config: ConfigType) -> None:
 Define the trigger class in `automation.h`. This example fires only on the off-to-on transition, requiring mutable state (`last_on_`) that cannot be stored in a pointer-sized forwarder:
 
 ```cpp
-class TurnOnTrigger : public Trigger<> {
+class TurnOnTrigger final : public Trigger<> {
  public:
   explicit TurnOnTrigger(MyComponent *parent) : parent_(parent) {
     parent->add_on_state_callback([this](bool state) {
@@ -227,7 +231,7 @@ Set `synchronous=True` if the action completes immediately (no async operations 
 ### C++
 
 ```cpp
-template<typename... Ts> class MyAction : public Action<Ts...> {
+template<typename... Ts> class MyAction final : public Action<Ts...> {
  public:
   explicit MyAction(MyComponent *parent) : parent_(parent) {}
 
@@ -243,7 +247,7 @@ template<typename... Ts> class MyAction : public Action<Ts...> {
 For actions that accept templatable values from the user config:
 
 ```cpp
-template<typename... Ts> class SetValueAction : public Action<Ts...> {
+template<typename... Ts> class SetValueAction final : public Action<Ts...> {
  public:
   explicit SetValueAction(MyComponent *parent) : parent_(parent) {}
   TEMPLATABLE_VALUE(bool, state)
@@ -307,7 +311,7 @@ async def my_condition_to_code(
 ### C++
 
 ```cpp
-template<typename... Ts> class MyCondition : public Condition<Ts...> {
+template<typename... Ts> class MyCondition final : public Condition<Ts...> {
  public:
   explicit MyCondition(MyComponent *parent) : parent_(parent) {}
   bool check(const Ts &...) override { return this->parent_->is_active(); }

--- a/docs/architecture/components/index.md
+++ b/docs/architecture/components/index.md
@@ -201,7 +201,7 @@ This represents the minimum required code to implement a component in ESPHome:
 
   namespace esphome::example_component {
 
-  class ExampleComponent : public Component {
+  class ExampleComponent final : public Component {
   public:
     void setup() override;
     void loop() override;
@@ -262,6 +262,10 @@ Any component exists as at least one C++ `class`. In ESPHome, components always 
 `PollingComponent` classes. The latter of these defines an additional `update()` method which is called on a periodic
 basis based on user configuration. This is often useful for hardware such as sensors which are queried periodically for
 a new measurement/reading.
+
+Note that `ExampleComponent` above is marked `final`: it is a *leaf* class that nothing else in ESPHome derives from.
+Mark your own user-configurable component and platform classes `final` unless another in-tree class subclasses them.
+See [Marking leaf classes as `final`](/contributing/code/#marking-leaf-classes-as-final) for details.
 
 ### Common methods
 

--- a/docs/contributing/code.md
+++ b/docs/contributing/code.md
@@ -96,6 +96,44 @@ class Buffer {
 };
 ```
 
+#### Marking leaf classes as `final`
+
+Mark a class with the C++ `final` specifier when nothing in the ESPHome tree derives from it. This applies to:
+
+- **User-configurable component and platform classes** — the class the user instantiates through their YAML (a specific
+  sensor, switch, display, etc.).
+- **Automation primitives** — the `Action`, `Trigger`, and `Condition` subclasses a component registers.
+
+```cpp
+// Leaf component class — nothing in the tree derives from it
+class MySensor final : public PollingComponent, public sensor::Sensor {
+  // ...
+};
+
+// Automation primitives are leaves too
+template<typename... Ts> class MyAction final : public Action<Ts...> { /* ... */ };
+template<typename... Ts> class MyTrigger final : public Trigger<Ts...> { /* ... */ };
+template<typename... Ts> class MyCondition final : public Condition<Ts...> { /* ... */ };
+```
+
+**Only mark a class `final` if it is never used as a base class anywhere in the ESPHome tree.** Hub classes, the
+`*Component` base classes that platform classes extend, and any class with an in-tree subclass are *not* leaves and
+must not be marked `final`. When in doubt, confirm that no other class derives from it before adding the keyword.
+
+Why we do this:
+
+- **It hardens the API surface.** External components can no longer subclass the class, so its undocumented
+  `public`/`protected` members remain free to change without breaking out-of-tree code (see
+  [What is Considered Public C++ API?](#what-is-considered-public-c-api)). Because external components *can* currently
+  subclass these classes, adding `final` is a [developer breaking change](#what-constitutes-a-c-breaking-change).
+- **It documents intent.** `final` states explicitly that the class is a terminal, configurable unit rather than an
+  extension point.
+- **It helps the compiler.** Marking a class `final` lets the compiler devirtualize calls made through it, which can
+  reduce flash usage.
+
+This was applied across the ESPHome tree in a series of PRs beginning with
+[esphome/esphome#16952](https://github.com/esphome/esphome/pull/16952).
+
 ### Memory management and heap allocation
 
 ESP devices run for months with small heaps shared between Wi-Fi, BLE, LWIP, and application code. Over time, repeated


### PR DESCRIPTION
## Summary

Documents the C++ `final` convention introduced across the [esphome/esphome#16952](https://github.com/esphome/esphome/pull/16952) PR series, which marks leaf, user-configurable component classes and automation `Action`/`Trigger`/`Condition` primitives as `final`.

- Adds a "Marking leaf classes as `final`" coding-standard subsection to `docs/contributing/code.md`, covering the rule, the "leaf only" caveat (hubs and base `*Component` classes excluded), and the rationale (API hardening / developer breaking change, intent, devirtualization).
- Marks the canonical `ExampleComponent` example `final` in `docs/architecture/components/index.md` with a cross-linked note.
- Marks the `Action`/`Trigger`/`Condition` examples `final` in `docs/architecture/components/automations.md` and adds an explanatory note.

Entity base-class docs (sensor, switch, etc.) are intentionally left untouched, since those classes are meant to be subclassed and must not be `final`.