### PR TITLE
Recommend a named package over the YAML merge key for common.yaml

### DIFF
--- a/src/content/docs/architecture/ci/component_tests.md
+++ b/src/content/docs/architecture/ci/component_tests.md
@@ -53,22 +53,23 @@ sensor:
 It's a shared configuration file that defines common settings used across all hardware platforms. Having a "common"
 file like this minimizes duplication and ensures test consistency across all platforms.
 
-To use `common.yaml` in a test configuration, YAML substitutions and the insertion operator are used (see
-[substitutions](https://esphome.io/components/substitutions)). This allows the test YAML file to reference and include
-the shared configuration. For the `dht12` platform, one of the test files is named `test.esp32-ard.yaml` and it contains
-this:
+To use `common.yaml` in a test configuration, YAML substitutions and a [package](https://esphome.io/components/packages)
+are used (see [substitutions](https://esphome.io/components/substitutions)). This allows the test YAML file to reference
+and include the shared configuration. For the `dht12` platform, one of the test files is named `test.esp32-ard.yaml` and
+it contains this:
 
 ```yaml
 substitutions:
   scl_pin: GPIO16
   sda_pin: GPIO17
 
-<<: !include common.yaml
+packages:
+  dht12: !include common.yaml
 ```
 
-By including `common.yaml`, all test configurations maintain the same structure while allowing flexibility for
-platform-specific substitutions such as pin assignments. This approach simplifies managing multiple test cases across
-different hardware platforms.
+By including `common.yaml` as a named package, all test configurations maintain the same structure while allowing
+flexibility for platform-specific substitutions such as pin assignments. This approach simplifies managing multiple test
+cases across different hardware platforms.
 
 ## Which tests do I need?
 


### PR DESCRIPTION
The component test docs recommended pulling in `common.yaml` with the YAML merge key insertion operator (`<<: !include common.yaml`). The merge key silently drops duplicate top-level keys, which is a subtle footgun. This switches the guidance to a named package keyed on the component name (`packages: { dht12: !include common.yaml }`), which is the clearer and safer pattern, and updates the surrounding prose to reference the packages docs.