### PR TITLE
Document the entity base classes and multi-entity config patterns

### DIFF
--- a/src/content/docs/architecture/components/alarm_control_panel.md
+++ b/src/content/docs/architecture/components/alarm_control_panel.md
@@ -87,6 +87,7 @@ class MyAlarm : public alarm_control_panel::AlarmControlPanel, public Component 
 
  protected:
   void control(const alarm_control_panel::AlarmControlPanelCall &call) override;
+  bool is_code_valid_(const optional<std::string> &code);
 
   std::string code_{};
   bool requires_code_to_arm_{false};
@@ -107,38 +108,58 @@ the front-end whether a code is needed to disarm, and whether that same code is 
 
 The one method you *must* implement is `control()`. The front-end (or an automation) builds an
 `AlarmControlPanelCall` - via helpers like `arm_away()`, `arm_home()`, `disarm()` on the entity itself, or directly
-via `make_call()` - and the base class dispatches it here after validating any code. Inspect `call.get_state()` for
-the requested state:
+via `make_call()` - and the base class dispatches it here. The base class checks only that the state transition is
+legal and supported; **it never looks at the code**, so enforcing it is entirely your job. Inspect `call.get_state()`
+for the requested state:
 
 ```cpp
-void MyAlarm::control(const alarm_control_panel::AlarmControlPanelCall &call) {
-  if (call.get_code().has_value() && !this->is_code_valid_(*call.get_code())) {
-    return;
-  }
+// Takes the optional itself, so an absent code is handled here rather than
+// by the caller. Returns true when no code is configured at all.
+bool MyAlarm::is_code_valid_(const optional<std::string> &code) {
+  if (this->code_.empty())
+    return true;
+  return code.has_value() && *code == this->code_;
+}
 
-  if (call.get_state().has_value()) {
-    switch (*call.get_state()) {
-      case alarm_control_panel::ACP_STATE_ARMED_AWAY:
-        this->arm_hardware_(alarm_control_panel::ACP_STATE_ARMED_AWAY);
-        break;
-      case alarm_control_panel::ACP_STATE_ARMED_HOME:
-        this->arm_hardware_(alarm_control_panel::ACP_STATE_ARMED_HOME);
-        break;
-      case alarm_control_panel::ACP_STATE_DISARMED:
-        this->disarm_hardware_();
-        break;
-      default:
-        break;
-    }
+void MyAlarm::control(const alarm_control_panel::AlarmControlPanelCall &call) {
+  if (!call.get_state().has_value())
+    return;
+
+  switch (*call.get_state()) {
+    case alarm_control_panel::ACP_STATE_ARMED_AWAY:
+    case alarm_control_panel::ACP_STATE_ARMED_HOME:
+      // Arming only needs a code when the user asked for one.
+      if (this->requires_code_to_arm_ && !this->is_code_valid_(call.get_code())) {
+        ESP_LOGW(TAG, "Not arming: code doesn't match");
+        return;
+      }
+      this->arm_hardware_(*call.get_state());
+      break;
+
+    case alarm_control_panel::ACP_STATE_DISARMED:
+      // Disarming always needs a valid code when one is configured.
+      if (!this->is_code_valid_(call.get_code())) {
+        ESP_LOGW(TAG, "Not disarming: code doesn't match");
+        return;
+      }
+      this->disarm_hardware_();
+      break;
+
+    default:
+      break;
   }
 }
 ```
 
 A few important details:
 
-- `AlarmControlPanelCall`'s getters (`get_state()`, `get_code()`) return `optional<T>`; the base class has already
-  run its own validation (e.g. rejecting an arm request when `get_requires_code_to_arm()` is true and no/incorrect
-  code was supplied) before `control()` is ever called.
+- `AlarmControlPanelCall`'s getters (`get_state()`, `get_code()`) return `optional<T>`. The base class's
+  `validate_()` only rejects illegal or unsupported state transitions (arming when not disarmed, arming a mode absent
+  from `get_supported_features()`, and so on). It does **not** check the code, so `control()` can be reached with no
+  code, or the wrong one, even when `get_requires_code_to_arm()` is true.
+- Because of that, check the code against the `optional` itself rather than only when it has a value. A guard like
+  `if (call.get_code().has_value() && !valid)` silently lets a code-less disarm straight through. Log a warning when
+  you reject a command, otherwise the command vanishes with no indication of why.
 - Once your hardware has actually reached the new state (which may take time - e.g. an exit delay before fully
   arming), call `publish_state(AlarmControlPanelState)` yourself to report it. The base class does not do this for
   you, which lets you model intermediate states like `ACP_STATE_ARMING` or `ACP_STATE_PENDING` before settling on

--- a/src/content/docs/architecture/components/alarm_control_panel.md
+++ b/src/content/docs/architecture/components/alarm_control_panel.md
@@ -2,4 +2,256 @@
 title: "Alarm Control Panel"
 ---
 
+The `alarm_control_panel` component is one of ESPHome's core [entity](/architecture/components/index) types. An
+alarm control panel represents a security system: it can be armed in several different modes (home, away, night,
+vacation), disarmed, and it reports intermediate states like pending or triggered. Unlike a
+[switch](/architecture/components/switch), which only toggles between two states, an alarm control panel exposes a
+small state machine and, optionally, a numeric code the user must supply to arm or disarm it.
 
+Like the other entity types, `alarm_control_panel` is a *platform* base. Individual components (for example
+`template`) register an alarm control panel and implement the logic that actually decides whether an arm/disarm
+request is accepted.
+
+## Python
+
+An alarm control panel platform lives in an `alarm_control_panel.py` file (or an `alarm_control_panel/__init__.py`
+package) inside your component's directory. This file name tells ESPHome that the component provides an
+`alarm_control_panel` platform, allowing the user to configure it under the `alarm_control_panel:` block:
+
+```yaml
+alarm_control_panel:
+  - platform: my_component
+    name: "My Alarm Panel"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import alarm_control_panel
+
+my_alarm_ns = cg.esphome_ns.namespace("my_alarm")
+MyAlarm = my_alarm_ns.class_("MyAlarm", alarm_control_panel.AlarmControlPanel, cg.Component)
+```
+
+Note that `MyAlarm` inherits from both `alarm_control_panel.AlarmControlPanel` and a component base (`cg.Component`
+here).
+
+### Configuration schema
+
+Use the `alarm_control_panel.alarm_control_panel_schema()` helper. It returns a schema pre-populated with the
+options common to every alarm control panel - `name`, `id`, `icon`, `entity_category`, and the `on_state` /
+`on_triggered` / `on_arming` / `on_pending` / `on_armed_home` / `on_armed_night` / `on_armed_away` / `on_disarmed` /
+`on_cleared` / `on_chime` / `on_ready` automations - and lets you pass defaults for your device:
+
+```python
+CONFIG_SCHEMA = alarm_control_panel.alarm_control_panel_schema(MyAlarm).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyAlarm`) as the first argument tells the helper which class to declare the ID for, so you do
+not need a separate `cv.GenerateID()`.
+
+### Code generation
+
+In `to_code`, use the `alarm_control_panel.new_alarm_control_panel()` helper. It calls `cg.new_Pvariable()` for you
+*and* generates all the code to apply the common options and callback automations from the configuration:
+
+```python
+async def to_code(config):
+    var = await alarm_control_panel.new_alarm_control_panel(config)
+    await cg.register_component(var, config)
+```
+
+If your component owns an alarm control panel as a child (rather than *being* one), use
+`await alarm_control_panel.register_alarm_control_panel(var, config)` instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `alarm_control_panel::AlarmControlPanel` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/alarm_control_panel/alarm_control_panel.h"
+
+namespace esphome::my_alarm {
+
+class MyAlarm : public alarm_control_panel::AlarmControlPanel, public Component {
+ public:
+  uint32_t get_supported_features() const override;
+  bool get_requires_code() const override { return !this->code_.empty(); }
+  bool get_requires_code_to_arm() const override { return this->requires_code_to_arm_; }
+
+  void set_code(const std::string &code) { this->code_ = code; }
+  void set_requires_code_to_arm(bool requires) { this->requires_code_to_arm_ = requires; }
+
+ protected:
+  void control(const alarm_control_panel::AlarmControlPanelCall &call) override;
+
+  std::string code_{};
+  bool requires_code_to_arm_{false};
+};
+
+}  // namespace esphome::my_alarm
+```
+
+### Reporting capabilities
+
+Before the front-end will offer arm-home/arm-night/etc. buttons, it needs to know which modes your panel supports.
+Implement `get_supported_features()` returning an OR of `AlarmControlPanelFeature` flags
+(`ACP_FEAT_ARM_HOME`, `ACP_FEAT_ARM_AWAY`, `ACP_FEAT_ARM_NIGHT`, `ACP_FEAT_ARM_VACATION`,
+`ACP_FEAT_ARM_CUSTOM_BYPASS`, `ACP_FEAT_TRIGGER`), and `get_requires_code()` / `get_requires_code_to_arm()` to tell
+the front-end whether a code is needed to disarm, and whether that same code is also needed to arm.
+
+### Handling commands
+
+The one method you *must* implement is `control()`. The front-end (or an automation) builds an
+`AlarmControlPanelCall` - via helpers like `arm_away()`, `arm_home()`, `disarm()` on the entity itself, or directly
+via `make_call()` - and the base class dispatches it here after validating any code. Inspect `call.get_state()` for
+the requested state:
+
+```cpp
+void MyAlarm::control(const alarm_control_panel::AlarmControlPanelCall &call) {
+  if (call.get_code().has_value() && !this->is_code_valid_(*call.get_code())) {
+    return;
+  }
+
+  if (call.get_state().has_value()) {
+    switch (*call.get_state()) {
+      case alarm_control_panel::ACP_STATE_ARMED_AWAY:
+        this->arm_hardware_(alarm_control_panel::ACP_STATE_ARMED_AWAY);
+        break;
+      case alarm_control_panel::ACP_STATE_ARMED_HOME:
+        this->arm_hardware_(alarm_control_panel::ACP_STATE_ARMED_HOME);
+        break;
+      case alarm_control_panel::ACP_STATE_DISARMED:
+        this->disarm_hardware_();
+        break;
+      default:
+        break;
+    }
+  }
+}
+```
+
+A few important details:
+
+- `AlarmControlPanelCall`'s getters (`get_state()`, `get_code()`) return `optional<T>`; the base class has already
+  run its own validation (e.g. rejecting an arm request when `get_requires_code_to_arm()` is true and no/incorrect
+  code was supplied) before `control()` is ever called.
+- Once your hardware has actually reached the new state (which may take time - e.g. an exit delay before fully
+  arming), call `publish_state(AlarmControlPanelState)` yourself to report it. The base class does not do this for
+  you, which lets you model intermediate states like `ACP_STATE_ARMING` or `ACP_STATE_PENDING` before settling on
+  the final one.
+- To report an alarm being triggered outside of a direct command (e.g. a sensor opened while armed), call
+  `publish_state(alarm_control_panel::ACP_STATE_TRIGGERED)` directly - this does not go through `control()`.
+
+### Useful members
+
+- `get_state()`: the current `AlarmControlPanelState` (`DISARMED` / `ARMED_HOME` / `ARMED_AWAY` / `ARMED_NIGHT` /
+  `ARMED_VACATION` / `ARMED_CUSTOM_BYPASS` / `PENDING` / `ARMING` / `DISARMING` / `TRIGGERED`).
+- `publish_state(AlarmControlPanelState)`: reports a new state to the front-end and fires the `on_state` /
+  `on_triggered` / etc. callbacks.
+- `is_state_armed(state)`: convenience check for whether a given state counts as "armed".
+- `add_on_cleared_callback()` / `add_on_chime_callback()` / `add_on_ready_callback()`: register callbacks for
+  events that are not simple state transitions - leaving the triggered state, a chime zone opening, or the panel's
+  overall "ready to arm" status changing.
+
+## Exposing multiple alarm control panels from one component
+
+Hardware sometimes splits a security system into more than one armable area - a panel with separate partitions for
+"downstairs" and "upstairs", each armed and disarmed independently. There are two established ways to model this.
+
+### A hub plus a `type` on the platform
+
+With a top-level hub already configured, add one `alarm_control_panel:` entry per partition, distinguished by
+`type`, via `cv.typed_schema()` with `key=CONF_TYPE`:
+
+```yaml
+security_panel:
+  id: the_panel
+
+alarm_control_panel:
+  - platform: security_panel
+    type: partition_1
+    name: "Downstairs"
+  - platform: security_panel
+    type: partition_2
+    name: "Upstairs"
+```
+
+```python
+from esphome.const import CONF_TYPE
+from .. import CONF_SECURITY_PANEL_ID, SecurityPanel, SecurityPanelPartition
+
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_SECURITY_PANEL_ID): cv.use_id(SecurityPanel)})
+_PARTITION_SCHEMA = alarm_control_panel.alarm_control_panel_schema(SecurityPanelPartition)
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "partition_1": _PARTITION_SCHEMA.extend(_HUB_ID_SCHEMA),
+        "partition_2": _PARTITION_SCHEMA.extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+async def to_code(config):
+    var = await alarm_control_panel.new_alarm_control_panel(config)
+    await cg.register_component(var, config)
+    await cg.register_parented(var, config[CONF_SECURITY_PANEL_ID])
+```
+
+Each partition is a first-class platform entry with the full option set, adding another partition later is purely
+additive, and different partitions can use different C++ classes if their capabilities diverge (for example one
+partition that requires a code and one that does not).
+
+### Sub-configs on a single platform entry
+
+Some components instead nest each partition as an optional sub-key under one platform entry (`partition_1:`,
+`partition_2:` under a single `- platform: security_panel`). Unlike `sensor_schema()`,
+`alarm_control_panel_schema()` requires a class argument, so each sub-config still passes one explicitly, typically
+the same shared class:
+
+```python
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(SecurityPanel),
+        cv.Optional("partition_1"): alarm_control_panel.alarm_control_panel_schema(SecurityPanelPartition),
+        cv.Optional("partition_2"): alarm_control_panel.alarm_control_panel_schema(SecurityPanelPartition),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+```
+
+No `SUB_ALARM_CONTROL_PANEL` macro exists, so declare the pointer members and setters by hand, and null-check them
+before use - the user may configure only one partition:
+
+```cpp
+class SecurityPanel : public Component {
+ public:
+  void set_partition_1_panel(alarm_control_panel::AlarmControlPanel *p) { this->partition_1_panel_ = p; }
+  void set_partition_2_panel(alarm_control_panel::AlarmControlPanel *p) { this->partition_2_panel_ = p; }
+ protected:
+  alarm_control_panel::AlarmControlPanel *partition_1_panel_{nullptr};
+  alarm_control_panel::AlarmControlPanel *partition_2_panel_{nullptr};
+};
+```
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device
+and its partitions, so let the hardware decide:
+
+- **Sub-configs** fit when the partitions are a small, fixed set reported by a single panel in one transaction - for
+  example a two-partition board that always reports both areas together. This keeps one physical panel to one YAML
+  block.
+- **A hub plus `type`** fits when the partitions are independent things that happen to share a connection -
+  especially when a hub component already exists because the device or transport must be configured once, or when
+  the set of partitions is large, open-ended, or different partitions need different C++ classes or update
+  strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses.
+In a new component with no hub, sub-configs are usually the smaller change.
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component) for a fully worked example of both patterns.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/alarm_control_panel.md
+++ b/src/content/docs/architecture/components/alarm_control_panel.md
@@ -83,7 +83,7 @@ class MyAlarm : public alarm_control_panel::AlarmControlPanel, public Component 
   bool get_requires_code_to_arm() const override { return this->requires_code_to_arm_; }
 
   void set_code(const std::string &code) { this->code_ = code; }
-  void set_requires_code_to_arm(bool requires) { this->requires_code_to_arm_ = requires; }
+  void set_requires_code_to_arm(bool code_to_arm) { this->requires_code_to_arm_ = code_to_arm; }
 
  protected:
   void control(const alarm_control_panel::AlarmControlPanelCall &call) override;

--- a/src/content/docs/architecture/components/binary_sensor.md
+++ b/src/content/docs/architecture/components/binary_sensor.md
@@ -2,4 +2,204 @@
 title: "Binary Sensor"
 ---
 
+The `binary_sensor` component is one of ESPHome's core [entity](/architecture/components/index) types. A binary
+sensor represents a single two-state (ON/OFF) measurement - a door being open or closed, motion being detected, a
+button being pressed, and so on - which is published to the front-end (Home Assistant, the web server, MQTT, etc.) as
+a boolean value. It is the read-only counterpart to [switch](/architecture/components/switch): a binary sensor only
+*reports* a state, it never accepts commands from the front-end.
 
+Rather than being used on its own, `binary_sensor` is a *platform* base: individual components (for example `gpio`,
+`pn532` or a PIR motion module) register one or more binary sensors and push new states into them whenever the
+underlying condition changes. If you are writing a component that detects a two-state condition, you will almost
+always expose that condition as a binary sensor.
+
+We have an [example, minimal binary sensor component](https://github.com/esphome/starter-components/tree/main/components/empty_binary_sensor)
+which is a good starting point.
+
+## Python
+
+A binary sensor platform lives in a `binary_sensor.py` file (or a `binary_sensor/__init__.py` package) inside your
+component's directory. This file name tells ESPHome that the component provides a `binary_sensor` platform, allowing
+the user to configure it under the `binary_sensor:` block:
+
+```yaml
+binary_sensor:
+  - platform: my_component
+    name: "My Contact"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+from esphome.const import DEVICE_CLASS_DOOR
+
+my_binary_sensor_ns = cg.esphome_ns.namespace("my_binary_sensor")
+MyBinarySensor = my_binary_sensor_ns.class_("MyBinarySensor", binary_sensor.BinarySensor, cg.Component)
+```
+
+Note that `MyBinarySensor` inherits from both `binary_sensor.BinarySensor` and a component base (`cg.Component` here,
+or `cg.PollingComponent` if you need to poll the hardware for a new state).
+
+### Configuration schema
+
+Use the `binary_sensor.binary_sensor_schema()` helper. It returns a schema pre-populated with all of the options
+common to every binary sensor - `name`, `id`, `icon`, `device_class`, `entity_category`, `filters`, the
+`on_press` / `on_release` / `on_click` automations, and so on - and lets you pass defaults for your device:
+
+```python
+CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(
+    MyBinarySensor,
+    device_class=DEVICE_CLASS_DOOR,
+).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyBinarySensor`) as the first argument tells the helper which class to declare the ID for, so you
+do not need a separate `cv.GenerateID()`.
+
+### Code generation
+
+In `to_code`, use the `binary_sensor.new_binary_sensor()` helper. It calls `cg.new_Pvariable()` for you *and*
+generates all the code to apply the common binary sensor options from the configuration:
+
+```python
+async def to_code(config):
+    var = await binary_sensor.new_binary_sensor(config)
+    await cg.register_component(var, config)
+```
+
+If your component owns a binary sensor as a child (rather than *being* a binary sensor), use
+`await binary_sensor.register_binary_sensor(var, config)` instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `binary_sensor::BinarySensor` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+
+namespace esphome::my_binary_sensor {
+
+class MyBinarySensor : public binary_sensor::BinarySensor, public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+};
+
+}  // namespace esphome::my_binary_sensor
+```
+
+### Publishing values
+
+`binary_sensor::BinarySensor` is a read-only entity: there is no command coming back from the front-end. Your only job
+is to push new states out. Whenever the condition you are monitoring changes, call `publish_state()`:
+
+```cpp
+void MyBinarySensor::loop() {
+  bool value = this->read_contact_();
+  this->publish_state(value);
+}
+```
+
+`publish_state()` takes the raw `bool` value, passes it through the user-configured filter chain (delayed on/off,
+inverting, debouncing, etc.), stores the final result in the `state` member and notifies all front-ends, including
+firing any `on_press` / `on_release` / `on_state` automations. Calling `publish_state()` repeatedly with the same
+value is cheap: the base class skips re-dispatching if the state has not actually changed.
+
+For the very first reading on boot, prefer `publish_initial_state()` instead of `publish_state()`. It sets the state
+the same way but does not fire the state-change callbacks, which avoids spuriously triggering `on_state_change`
+automations for a value the device is reporting for the first time rather than transitioning to.
+
+### Useful members
+
+- `state`: the most recent published (filtered) value.
+- `has_state()`: whether a value has ever been published.
+- `publish_state(bool)` / `publish_initial_state(bool)`: report a new state to the front-end.
+- `LOG_BINARY_SENSOR(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the binary sensor's name
+  and device class in the standard format.
+
+## Exposing multiple binary sensors from one component
+
+Hardware often maps to more than one binary sensor - a multi-channel input expander reports several contacts, and an
+alarm panel hub exposes a zone contact per configured zone. There are two established ways to model this. Both are
+valid and both are widely used in-tree - which one fits depends on how the hardware itself is shaped, so read the two
+together and pick the one that describes your device more honestly.
+
+### A hub plus a `type` on the platform
+
+If your component already has a top-level hub, let the user add *one `binary_sensor:` entry per contact*,
+distinguished by a `type` key, using `cv.typed_schema()` with `key=CONF_TYPE`:
+
+```yaml
+binary_sensor:
+  - platform: my_hub
+    type: zone_1
+    name: "Zone 1"
+  - platform: my_hub
+    type: zone_2
+    name: "Zone 2"
+```
+
+```python
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_MY_HUB_ID): cv.use_id(MyHub)})
+
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "zone_1": binary_sensor.binary_sensor_schema(MyHubZoneBinarySensor).extend(_HUB_ID_SCHEMA),
+        "zone_2": binary_sensor.binary_sensor_schema(MyHubZoneBinarySensor).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+async def to_code(config):
+    var = await binary_sensor.new_binary_sensor(config)
+    await cg.register_parented(var, config[CONF_MY_HUB_ID])
+```
+
+Each entry is a first-class platform entry with the full set of per-entity options, adding a new zone later is purely
+additive, and different zones could use different C++ classes - see the `binary_sensor` platform of `packet_transport`
+for a real, in-tree example.
+
+### Sub-configs on a single platform entry
+
+Many components instead nest optional sub-keys under one platform entry, each an inline
+`binary_sensor.binary_sensor_schema()` called without a class argument - [`ld2410`](https://github.com/esphome/esphome/tree/dev/esphome/components/ld2410)
+does this for `has_target`, `has_moving_target` and `has_still_target`. Use `SUB_BINARY_SENSOR(name)` from
+`binary_sensor.h`, which generates a protected `name##_binary_sensor_` member (defaulted to `nullptr`) and a public
+`set_##name##_binary_sensor()` setter. Always null-check before publishing, since the user may have configured only
+some of them:
+
+```cpp
+class MyComponent final : public Component {
+ public:
+  SUB_BINARY_SENSOR(moving_target)
+  SUB_BINARY_SENSOR(still_target)
+};
+// this->moving_target_binary_sensor_->publish_state(moving); once null-checked
+```
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component)
+for a fully worked example of both patterns.
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device
+and its contacts, so let the hardware decide:
+
+- **Sub-configs** fit when the contacts are facets of one inseparable read cycle. `ld2410` reads `has_target`,
+  `has_moving_target` and `has_still_target` from a single sensor frame, so one entry with several optional sub-keys
+  mirrors what the chip actually reports. This also keeps one physical device to one YAML block, which is easier to
+  read.
+- **A hub plus `type`** fits when the contacts are genuinely independent things that happen to share a connection. If
+  a hub component already exists because the device or transport must be configured once and shared, then each
+  contact being its own entry is the more natural fit - especially when the set is large or open-ended, or when
+  different contacts need different C++ classes or update strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/button.md
+++ b/src/content/docs/architecture/components/button.md
@@ -2,4 +2,205 @@
 title: "Button"
 ---
 
+The `button` component is one of ESPHome's core [entity](/architecture/components/index) types. Unlike a
+[switch](/architecture/components/switch), a button has no persistent state - it is a momentary, stateless entity that
+only knows how to be *pressed*. There is nothing to publish and nothing to read back; pressing the button simply
+triggers a one-shot action on the device (rebooting, sending a single IR code, factory-resetting, and so on).
 
+Like the other entity types, `button` is a *platform* base. Individual components (for example `restart`, `safe_mode`
+or `factory_reset`) register a button and implement the action that should run when it is pressed.
+
+## Python
+
+A button platform lives in a `button.py` file (or a `button/__init__.py` package) inside your component's directory.
+This file name tells ESPHome that the component provides a `button` platform, allowing the user to configure it under
+the `button:` block:
+
+```yaml
+button:
+  - platform: my_component
+    name: "My Button"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import button
+
+my_button_ns = cg.esphome_ns.namespace("my_button")
+MyButton = my_button_ns.class_("MyButton", button.Button, cg.Component)
+```
+
+Note that `MyButton` inherits from both `button.Button` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+Use the `button.button_schema()` helper. It returns a schema pre-populated with all of the options common to every
+button - `name`, `id`, `icon`, `entity_category`, `device_class`, the `on_press` automation, and so on - and lets you
+pass defaults for your device:
+
+```python
+CONFIG_SCHEMA = button.button_schema(MyButton).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyButton`) as the first argument tells the helper which class to declare the ID for, so you do not
+need a separate `cv.GenerateID()`.
+
+### Code generation
+
+In `to_code`, use the `button.new_button()` helper. It calls `cg.new_Pvariable()` for you *and* generates all the code
+to apply the common button options from the configuration:
+
+```python
+async def to_code(config):
+    var = await button.new_button(config)
+    await cg.register_component(var, config)
+```
+
+If your component owns a button as a child (rather than *being* a button), use `await button.register_button(var, config)`
+instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `button::Button` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/button/button.h"
+
+namespace esphome::my_button {
+
+class MyButton : public button::Button, public Component {
+ public:
+  void dump_config() override;
+
+ protected:
+  void press_action() override;
+};
+
+}  // namespace esphome::my_button
+```
+
+### Handling the press
+
+A button has no `write_state()`-style method taking a value - there is nothing to write. Instead, the front-end calls
+the public `press()` method, which the base class uses to log the event, invoke your `press_action()` override, and
+finally fire any `on_press` automations. The one method you *must* implement is `press_action()`:
+
+```cpp
+void MyButton::press_action() {
+  // Perform the one-shot action here.
+  this->write_command_to_hardware_();
+}
+```
+
+A few important details:
+
+- `press_action()` is called synchronously from `press()`; there is no state to publish and no `publish_state()` call to
+  make afterwards.
+- If the action needs to un-do itself after a delay (for example a relay pulse), use `set_timeout()` from within
+  `press_action()` rather than blocking - see [`output_button`](https://github.com/esphome/esphome/blob/dev/esphome/components/output/button/output_button.cpp)
+  for an example that turns an output on and schedules it back off.
+- Do not implement `press()` yourself - it is provided by the base class and calls your `press_action()` for you.
+
+### Useful members
+
+- `add_on_press_callback(F &&callback)`: register an additional `void()` callback to run whenever the button is
+  pressed, in case you need to react to a press outside of `press_action()` itself.
+- `LOG_BUTTON(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the button in the standard format.
+
+## Exposing multiple buttons from one component
+
+Hardware often maps to more than one button - a hub component might expose a reboot button, a calibrate button and a
+clear-counters button, all acting on the same underlying device. There are two established ways to model this. Both
+are valid and both are widely used in-tree - which one fits depends on how the hardware itself is shaped, so read the
+two together and pick the one that describes your device more honestly.
+
+### A hub plus a `type` on the platform
+
+If your component already has a top-level hub, let the user add *one `button:` entry per action*, distinguished by a
+`type` key, using `cv.typed_schema()` with `key=CONF_TYPE`:
+
+```yaml
+button:
+  - platform: my_hub
+    type: reboot
+    name: "Reboot"
+  - platform: my_hub
+    type: calibrate
+    name: "Calibrate"
+```
+
+```python
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_MY_HUB_ID): cv.use_id(MyHub)})
+
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "reboot": button.button_schema(MyHubRebootButton).extend(_HUB_ID_SCHEMA),
+        "calibrate": button.button_schema(MyHubCalibrateButton).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+async def to_code(config):
+    var = await button.new_button(config)
+    await cg.register_parented(var, config[CONF_MY_HUB_ID])
+```
+
+Each entry is a first-class platform entry with the full set of per-entity options, adding a new action later is
+purely additive, and each action naturally gets its own `press_action()` via its own C++ class.
+
+### Sub-configs on a single platform entry
+
+Many components instead nest optional sub-keys under one platform entry, one per action. Note an important difference
+from the sensor case: `sensor_schema()` can be called with no class at all, because `sensor::Sensor` is concrete and a
+bare instance is perfectly usable - it just holds a value. `button::Button` is abstract: `press_action()` is pure
+virtual, so there is no generic button to fall back on and every button needs its own subclass. `button_schema()`
+reflects that by making `class_` a required argument rather than defaulting it to `cv.UNDEFINED`.
+
+> [!NOTE]
+> Whether the Python helper *enforces* this varies by entity type and is partly historical: `text_schema()`,
+> `lock_schema()` and `valve_schema()` all default `class_` even though those base classes are abstract too, so omitting
+> the class there fails later at C++ compile time instead of during validation. The rule to follow is to pass a concrete
+> subclass whenever the base class is abstract, whether or not the helper forces you to. Only `sensor`,
+> `binary_sensor`, `text_sensor` and `event` have non-abstract bases where omitting it genuinely works.
+
+So every sub-config, even inline ones, must still declare and pass its own concrete class, exactly as
+[`ld2450`](https://github.com/esphome/esphome/tree/dev/esphome/components/ld2450) does for its `factory_reset` and
+`restart` sub-configs: `cv.Optional(CONF_FACTORY_RESET): button.button_schema(FactoryResetButton)`, with
+`FactoryResetButton` declared as its own `button.Button` subclass.
+
+The hub still uses `SUB_BUTTON(name)` from `button.h`, which generates a protected `name##_button_` member (defaulted
+to `nullptr`) and a public `set_##name##_button()` setter, exactly as for the other entity types. Always null-check
+before calling into a sub-button, since the user may have configured only some of them:
+
+```cpp
+class MyHubComponent final : public Component {
+ public:
+  SUB_BUTTON(factory_reset)
+  SUB_BUTTON(restart)
+};
+// if (this->factory_reset_button_ != nullptr) { ... }
+```
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component)
+for a fully worked example of both patterns.
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device
+and its actions, so let the hardware decide:
+
+- **Sub-configs** fit when the actions are facets of one inseparable set that a single device exposes together.
+  `ld2450` offers `factory_reset` and `restart` as sub-configs of the one radar entry, so a single YAML block for the
+  device is easier to read than several separate platform entries.
+- **A hub plus `type`** fits when the actions are genuinely independent things that happen to share a connection. If
+  a hub component already exists because the device or transport must be configured once and shared, then each
+  action being its own entry is the more natural fit - especially when the set is large or open-ended, or when
+  different actions need different `press_action()` implementations or update strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses.
+
+For everything else, the component implements the usual set of methods [as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/climate.md
+++ b/src/content/docs/architecture/components/climate.md
@@ -2,4 +2,274 @@
 title: "Climate"
 ---
 
+The `climate` component is one of ESPHome's core [entity](/architecture/components/index) types. A climate entity
+represents a device that controls the temperature (and, optionally, humidity) of an environment - an AC unit, a
+thermostat, a heat pump, a bang-bang controller driven by a [sensor](/architecture/components/sensor), and so on. It is
+one of the more involved entity types: unlike a [switch](/architecture/components/switch), which only has a boolean
+state, a climate entity has several independent pieces of state (mode, target temperature(s), fan mode, swing mode,
+preset, action) and each device only supports a subset of them.
 
+Like the other entity types, `climate` is a *platform* base. Individual components (for example `bang_bang`,
+`thermostat`, `pid`, or any of the various IR/UART-driven AC integrations) register a climate entity and implement the
+logic that translates user commands into whatever the underlying hardware or protocol needs.
+
+## Python
+
+A climate platform lives in a `climate.py` file (or a `climate/__init__.py` package) inside your component's
+directory. This file name tells ESPHome that the component provides a `climate` platform, allowing the user to
+configure it under the `climate:` block:
+
+```yaml
+climate:
+  - platform: my_component
+    name: "My Climate"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import climate
+
+my_climate_ns = cg.esphome_ns.namespace("my_climate")
+MyClimate = my_climate_ns.class_("MyClimate", climate.Climate, cg.Component)
+```
+
+Note that `MyClimate` inherits from both `climate.Climate` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+Use the `climate.climate_schema()` helper. It returns a schema pre-populated with all of the options common to every
+climate entity - `name`, `id`, `icon`, `visual` (min/max temperature, temperature step, min/max humidity), the
+`on_state` / `on_control` automations, MQTT topics, and so on - and lets you pass defaults for your device:
+
+```python
+CONFIG_SCHEMA = climate.climate_schema(MyClimate).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyClimate`) as the first argument tells the helper which class to declare the ID for, so you do
+not need a separate `cv.GenerateID()`.
+
+### Code generation
+
+In `to_code`, use the `climate.new_climate()` helper. It calls `cg.new_Pvariable()` for you *and* generates all the
+code to apply the common climate options (visual bounds, MQTT topics, `on_state`/`on_control` automations, etc.) from
+the configuration:
+
+```python
+async def to_code(config):
+    var = await climate.new_climate(config)
+    await cg.register_component(var, config)
+```
+
+If your component owns a climate entity as a child (rather than *being* a climate entity), use
+`await climate.register_climate(var, config)` instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `climate::Climate` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/climate/climate.h"
+
+namespace esphome::my_climate {
+
+class MyClimate : public climate::Climate, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  climate::ClimateTraits traits() override;
+  void control(const climate::ClimateCall &call) override;
+};
+
+}  // namespace esphome::my_climate
+```
+
+`climate::Climate` declares two pure virtual methods that every implementation must provide: `traits()` and
+`control()`.
+
+### Declaring capabilities with `traits()`
+
+`traits()` returns a `ClimateTraits` describing what this device can do. Only `CLIMATE_MODE_OFF` and a target
+temperature are supported by default; everything else must be declared explicitly, either as a feature flag
+(`ClimateFeature` in `climate_mode.h`) or as a supported-value set:
+
+```cpp
+climate::ClimateTraits MyClimate::traits() {
+  auto traits = climate::ClimateTraits();
+  traits.set_supported_modes({
+      climate::CLIMATE_MODE_OFF,
+      climate::CLIMATE_MODE_HEAT,
+      climate::CLIMATE_MODE_COOL,
+  });
+  traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | climate::CLIMATE_SUPPORTS_ACTION);
+  traits.set_visual_min_temperature(10.0f);
+  traits.set_visual_max_temperature(30.0f);
+  traits.set_visual_temperature_step(0.5f);
+  return traits;
+}
+```
+
+Useful `ClimateTraits` setters include `set_supported_modes()` / `add_supported_mode()`, `set_supported_fan_modes()` /
+`add_supported_fan_mode()`, `set_supported_swing_modes()` / `add_supported_swing_mode()`, `set_supported_presets()` /
+`add_supported_preset()`, and `set_visual_min_temperature()` / `set_visual_max_temperature()` /
+`set_visual_temperature_step()` / `set_visual_min_humidity()` / `set_visual_max_humidity()`. Capabilities such as
+reporting current temperature/humidity, target humidity, two-point target temperature, or the current action are
+declared through `add_feature_flags()` with the `CLIMATE_SUPPORTS_*` / `CLIMATE_REQUIRES_*` flags in `climate_mode.h`
+rather than a boolean setter, so check that header for the exact set of flags your device needs. Custom (free-text)
+fan modes and presets are declared on the `Climate` entity itself via `set_supported_custom_fan_modes()` /
+`set_supported_custom_presets()`, not on the traits object.
+
+### Handling commands with `control()`
+
+Whenever the front-end (Home Assistant, the web server, MQTT, a `climate.control` action, etc.) wants to change the
+device, it builds a `ClimateCall` (via `id(my_climate).make_call()`) and the base class forwards it to your
+`control()` override. Each field you support is exposed as an `optional<T>` getter - `get_mode()`,
+`get_target_temperature()`, `get_target_temperature_low()` / `get_target_temperature_high()`,
+`get_target_humidity()`, `get_fan_mode()`, `get_swing_mode()`, `get_preset()` - which is only set when the caller
+actually wants to change that property:
+
+```cpp
+void MyClimate::control(const climate::ClimateCall &call) {
+  if (call.get_mode().has_value()) {
+    this->mode = *call.get_mode();
+    // ... drive hardware into the new mode ...
+  }
+  if (call.get_target_temperature().has_value()) {
+    this->target_temperature = *call.get_target_temperature();
+    // ... send the new setpoint to the hardware ...
+  }
+
+  this->action = this->mode == climate::CLIMATE_MODE_OFF ? climate::CLIMATE_ACTION_OFF : climate::CLIMATE_ACTION_HEATING;
+  this->publish_state();
+}
+```
+
+Check each property you declared support for in `traits()`, apply it to the hardware, update the corresponding public
+member (`mode`, `target_temperature`/`target_temperature_low`/`target_temperature_high`, `target_humidity`,
+`fan_mode`, `swing_mode`, `preset`, `action`), and finish by calling `this->publish_state()` to notify the front-end of
+the new state. Read-only updates - for example a temperature sensor poll updating `current_temperature` - also just
+set the member and call `publish_state()`, without going through `control()`.
+
+### Enums
+
+- `ClimateMode`: `CLIMATE_MODE_OFF`, `CLIMATE_MODE_HEAT_COOL`, `CLIMATE_MODE_COOL`, `CLIMATE_MODE_HEAT`,
+  `CLIMATE_MODE_FAN_ONLY`, `CLIMATE_MODE_DRY`, `CLIMATE_MODE_AUTO`.
+- `ClimateAction`: what the device is actually doing right now (`CLIMATE_ACTION_OFF`, `CLIMATE_ACTION_COOLING`,
+  `CLIMATE_ACTION_HEATING`, `CLIMATE_ACTION_IDLE`, `CLIMATE_ACTION_DRYING`, `CLIMATE_ACTION_FAN`,
+  `CLIMATE_ACTION_DEFROSTING`), only meaningful if `CLIMATE_SUPPORTS_ACTION` is declared.
+- `ClimateFanMode` and `ClimateSwingMode`: the built-in fan/swing options (`CLIMATE_FAN_ON`/`OFF`/`AUTO`/`LOW`/etc.,
+  `CLIMATE_SWING_OFF`/`BOTH`/`VERTICAL`/`HORIZONTAL`).
+- `ClimatePreset`: built-in presets (`CLIMATE_PRESET_NONE`, `HOME`, `AWAY`, `BOOST`, `COMFORT`, `ECO`, `SLEEP`,
+  `ACTIVITY`).
+
+### Useful members
+
+- `mode`, `action`, `swing_mode`, `fan_mode`, `preset`, `target_temperature` (or `target_temperature_low` /
+  `target_temperature_high` for two-point devices), `target_humidity`, `current_temperature`, `current_humidity`: the
+  entity's current state, read-only for the user and read-write for the integration.
+- `make_call()`: build a `ClimateCall` to control this device (used internally by the front-end, and directly from
+  lambdas: `id(my_climate).make_call().set_mode(climate::CLIMATE_MODE_HEAT).perform();`).
+- `publish_state()`: push the current member values out to the front-end and persist them to flash for restore-on-boot.
+- `get_traits()`: get this device's `ClimateTraits`, with any user-configured visual overrides already applied.
+- `LOG_CLIMATE(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the climate entity's name in the
+  standard format.
+
+## Exposing multiple climate entities from one component
+
+Hardware sometimes controls more than one climate zone from a single device - a multi-zone ducted HVAC controller, or
+a multi-room heat pump hub with one indoor unit per room. There are two established ways to model this.
+
+### A hub plus a `type` on the platform
+
+With a top-level hub already configured, add one `climate:` entry per zone, distinguished by `type`, via
+`cv.typed_schema()` with `key=CONF_TYPE`:
+
+```yaml
+multizone_hvac:
+  id: the_hvac
+
+climate:
+  - platform: multizone_hvac
+    type: zone_1
+    name: "Living Room"
+  - platform: multizone_hvac
+    type: zone_2
+    name: "Bedroom"
+```
+
+```python
+from esphome.const import CONF_TYPE
+from .. import CONF_MULTIZONE_HVAC_ID, MultizoneHvac, MultizoneHvacZone
+
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_MULTIZONE_HVAC_ID): cv.use_id(MultizoneHvac)})
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "zone_1": climate.climate_schema(MultizoneHvacZone).extend(_HUB_ID_SCHEMA),
+        "zone_2": climate.climate_schema(MultizoneHvacZone).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+async def to_code(config):
+    var = await climate.new_climate(config)
+    await cg.register_component(var, config)
+    await cg.register_parented(var, config[CONF_MULTIZONE_HVAC_ID])
+```
+
+Each zone is a first-class platform entry with the full option set, and adding another zone later is purely
+additive. `haier/climate.py` is a real in-tree example of `cv.typed_schema()` wrapping `climate_schema()` (there it
+picks a device protocol rather than a zone, but the mechanics are identical).
+
+### Sub-configs on a single platform entry
+
+Some components nest each zone as an optional sub-key under one platform entry instead (`zone_1:`, `zone_2:` under a
+single `- platform: multizone_hvac`). Unlike `sensor_schema()`, `climate_schema()` requires a class argument, so each
+sub-config still passes one explicitly, typically the same shared class:
+
+```python
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(MultizoneHvac),
+        cv.Optional("zone_1"): climate.climate_schema(MultizoneHvacZone),
+        cv.Optional("zone_2"): climate.climate_schema(MultizoneHvacZone),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+```
+
+No `SUB_CLIMATE` macro exists, so declare the pointer members and setters by hand, and null-check them before use:
+
+```cpp
+class MultizoneHvac : public Component {
+ public:
+  void set_zone_1_climate(climate::Climate *c) { this->zone_1_climate_ = c; }
+  void set_zone_2_climate(climate::Climate *c) { this->zone_2_climate_ = c; }
+ protected:
+  climate::Climate *zone_1_climate_{nullptr};
+  climate::Climate *zone_2_climate_{nullptr};
+};
+```
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device
+and its climate zones, so let the hardware decide:
+
+- **Sub-configs** fit when the zones are read and driven together as part of one controller's single transaction -
+  for example a small multi-zone controller that always reports all of its zones at once. This keeps one physical
+  controller to one YAML block.
+- **A hub plus `type`** fits when the zones are genuinely independent things that happen to share a connection -
+  especially when a hub component already exists because the device or transport must be configured once, or when
+  the set of zones is large, open-ended, or different zones need different C++ classes or update strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses.
+In a new component with no hub, sub-configs are usually the smaller change.
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component) for a fully worked example of both patterns.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/cover.md
+++ b/src/content/docs/architecture/components/cover.md
@@ -2,4 +2,238 @@
 title: "Cover"
 ---
 
+The `cover` component is one of ESPHome's core [entity](/architecture/components/index) types. A cover represents
+anything that opens and closes and can be moved to a position - a garage door, a blind, a curtain, an awning, and so
+on. It is a *controllable* entity: in addition to reporting its current position (and, optionally, tilt) it accepts
+open/close/stop/toggle commands and can be asked to move to a specific position from the front-end (Home Assistant,
+the web server, MQTT, etc.).
 
+Like the other entity types, `cover` is a *platform* base. Individual components (for example a garage door relay, a
+shutter motor controller, or a curtain motor) register a cover and implement the logic that actually drives the
+hardware.
+
+We have an [example, minimal cover component](https://github.com/esphome/starter-components/tree/main/components/empty_cover)
+which is a good starting point.
+
+## Python
+
+A cover platform lives in a `cover.py` file (or a `cover/__init__.py` package) inside your component's directory. This
+file name tells ESPHome that the component provides a `cover` platform, allowing the user to configure it under the
+`cover:` block:
+
+```yaml
+cover:
+  - platform: my_component
+    name: "My Cover"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import cover
+
+my_cover_ns = cg.esphome_ns.namespace("my_cover")
+MyCover = my_cover_ns.class_("MyCover", cover.Cover, cg.Component)
+```
+
+Note that `MyCover` inherits from both `cover.Cover` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+Use the `cover.cover_schema()` helper. It returns a schema pre-populated with all of the options common to every
+cover - `name`, `id`, `icon`, `device_class`, `entity_category`, the `on_opened` / `on_closed` / `on_opening` /
+`on_closing` / `on_idle` automations, and so on:
+
+```python
+CONFIG_SCHEMA = cover.cover_schema(MyCover).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyCover`) as the first argument tells the helper which class to declare the ID for, so you do not
+need a separate `cv.GenerateID()`.
+
+### Code generation
+
+In `to_code`, use the `cover.new_cover()` helper. It calls `cg.new_Pvariable()` for you *and* generates all the code to
+apply the common cover options from the configuration:
+
+```python
+async def to_code(config):
+    var = await cover.new_cover(config)
+    await cg.register_component(var, config)
+```
+
+If your component owns a cover as a child (rather than *being* a cover), use `await cover.register_cover(var, config)`
+instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `cover::Cover` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/cover/cover.h"
+
+namespace esphome::my_cover {
+
+class MyCover : public cover::Cover, public Component {
+ public:
+  void dump_config() override;
+  cover::CoverTraits get_traits() override;
+
+ protected:
+  void control(const cover::CoverCall &call) override;
+};
+
+}  // namespace esphome::my_cover
+```
+
+### Command flow
+
+Unlike a [switch](/architecture/components/switch), where the front-end calls a single public setter, a cover command
+is built up as a `CoverCall` object: the front-end (or your own code) calls `make_call()` to get one, sets whichever
+fields it wants to change (`set_position()`, `set_tilt()`, `set_command_open()`, `set_stop()`, ...), and then calls
+`perform()` on it. This in turn dispatches to your protected virtual `control()` method with the finished call.
+
+The two methods you *must* implement are `control(const CoverCall &call)` and `get_traits()`.
+
+```cpp
+void MyCover::control(const CoverCall &call) {
+  if (call.get_stop()) {
+    this->stop_hardware_();
+    this->current_operation = COVER_OPERATION_IDLE;
+    this->publish_state();
+  }
+
+  if (call.get_position().has_value()) {
+    float pos = *call.get_position();
+    this->move_to_position_(pos);
+    this->position = pos;
+    this->publish_state();
+  }
+
+  if (call.get_tilt().has_value()) {
+    this->tilt = *call.get_tilt();
+    this->publish_state();
+  }
+}
+
+cover::CoverTraits MyCover::get_traits() {
+  auto traits = cover::CoverTraits();
+  traits.set_supports_position(true);
+  traits.set_supports_tilt(false);
+  traits.set_is_assumed_state(false);
+  return traits;
+}
+```
+
+A few important details:
+
+- Inspect `call.get_position()`, `call.get_tilt()` and `call.get_stop()` to find out what the caller actually asked
+  for; only the fields the caller set will be present (`get_position()`/`get_tilt()` are `optional<float>`, so check
+  `has_value()` before dereferencing).
+- `get_position()` and `get_tilt()` range from `0.0` (`COVER_CLOSED`) to `1.0` (`COVER_OPEN`) - use these constants
+  rather than the raw literals where it improves readability.
+- After driving the hardware, update `this->position` (and `this->tilt`, if supported) and set `this->current_operation`
+  before calling `publish_state()`, so the front-end sees an accurate, up-to-date state.
+- `get_traits()` tells the front-end what the cover can do - whether it supports a continuous `position`, `tilt`,
+  being stopped mid-move, or only reports an *assumed* state (see below). Report only the capabilities your hardware
+  actually has; the front-end adapts its UI accordingly (e.g. a cover that only supports open/close shows simple
+  buttons instead of a position slider).
+
+### Assumed state
+
+If your cover cannot read back the real hardware position (so the reported position is only what ESPHome last
+commanded), set `traits.set_is_assumed_state(true)` in `get_traits()`. The front-end will then show separate open/close
+controls rather than trusting the reported position as ground truth.
+
+### Useful members
+
+- `position`: the current reported position, `0.0` (closed) to `1.0` (open). Use `COVER_OPEN` / `COVER_CLOSED` for the
+  extremes.
+- `tilt`: the current reported tilt, on the same `0.0`-`1.0` scale.
+- `current_operation`: one of `COVER_OPERATION_IDLE`, `COVER_OPERATION_OPENING`, `COVER_OPERATION_CLOSING`.
+- `is_fully_open()` / `is_fully_closed()`: convenience helpers comparing `position` against `1.0` / `0.0`.
+- `publish_state(bool save = true)`: report the current `position`/`tilt`/`current_operation` to the front-end; pass
+  `save = false` to skip persisting the state to flash.
+- `LOG_COVER(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the cover in the standard format.
+
+## Exposing multiple covers from one component
+
+Hardware sometimes drives more than one cover from a single controller - a multi-channel blind/shutter controller hub
+might expose a roller shade on one channel and a tilting venetian blind on another. There are two established ways to
+model this. Both are valid and both are widely used in-tree - which one fits depends on how the hardware itself is
+shaped, so read the two together and pick the one that describes your device more honestly.
+
+### A hub plus a `type` on the platform
+
+If your component has a top-level hub, let the user add *one `cover:` entry per channel*, distinguished by a `type`
+key, using `cv.typed_schema()` with `key=CONF_TYPE`:
+
+```yaml
+my_hub:
+  id: the_hub
+cover:
+  - platform: my_hub
+    type: roller
+    name: "Living Room Blind"
+  - platform: my_hub
+    type: venetian
+    name: "Kitchen Blind"
+```
+
+```python
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_MY_HUB_ID): cv.use_id(MyHub)})
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "roller": cover.cover_schema(MyHubRollerCover).extend(_HUB_ID_SCHEMA),
+        "venetian": cover.cover_schema(MyHubVenetianCover).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+async def to_code(config):
+    var = await cover.new_cover(config)
+    await cg.register_component(var, config)
+    await cg.register_parented(var, config[CONF_MY_HUB_ID])
+```
+
+Each `type` gets its own schema and C++ class (only the venetian one needs `set_supports_tilt(true)` in
+`get_traits()`), and adding a third type later is purely additive. See
+[Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component)
+for a fully worked example.
+
+### Sub-configs on a single platform entry
+
+Some components instead nest their channels as optional sub-keys under one platform entry, the way
+[`dht`](https://github.com/esphome/esphome/tree/dev/esphome/components/dht) nests `temperature:` and `humidity:`
+under one `sensor:` entry. There is no `SUB_COVER` macro (only `binary_sensor`, `button`, `number`, `select`,
+`sensor`, `switch`, `text_sensor` have one), and unlike `sensor.sensor_schema()`, `cover.cover_schema()` always
+requires a class argument. Declare the pointer member and setter by hand, and null-check before use:
+
+```cpp
+class MyHubComponent : public Component {
+ public:
+  void set_channel_0_cover(cover::Cover *cover) { this->channel_0_cover_ = cover; }
+ protected:
+  cover::Cover *channel_0_cover_{nullptr};
+};
+```
+
+### Choosing between them
+
+Neither pattern is deprecated; they express different relationships between a controller and the covers it drives,
+so let the hardware decide:
+
+- **Sub-configs** fit when the channels are a small, fixed set on a single controller board - one physical device
+  maps to one YAML block, which is easier to read.
+- **A hub plus `type`** fits when a hub component already exists to describe the connection, and the set of channels
+  is large or open-ended, or different channels need different traits (only the venetian type needs
+  `set_supports_tilt(true)`) or C++ classes.
+
+If both descriptions fit equally well, follow whichever pattern the surrounding component already uses. In a new
+component with no hub, sub-configs are usually the smaller change.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/cover.md
+++ b/src/content/docs/architecture/components/cover.md
@@ -92,17 +92,17 @@ class MyCover : public cover::Cover, public Component {
 ### Command flow
 
 Unlike a [switch](/architecture/components/switch), where the front-end calls a single public setter, a cover command
-is built up as a `CoverCall` object: the front-end (or your own code) calls `make_call()` to get one, sets whichever
+is built up as a `cover::CoverCall` object: the front-end (or your own code) calls `make_call()` to get one, sets whichever
 fields it wants to change (`set_position()`, `set_tilt()`, `set_command_open()`, `set_stop()`, ...), and then calls
 `perform()` on it. This in turn dispatches to your protected virtual `control()` method with the finished call.
 
-The two methods you *must* implement are `control(const CoverCall &call)` and `get_traits()`.
+The two methods you *must* implement are `control(const cover::CoverCall &call)` and `get_traits()`.
 
 ```cpp
-void MyCover::control(const CoverCall &call) {
+void MyCover::control(const cover::CoverCall &call) {
   if (call.get_stop()) {
     this->stop_hardware_();
-    this->current_operation = COVER_OPERATION_IDLE;
+    this->current_operation = cover::COVER_OPERATION_IDLE;
     this->publish_state();
   }
 
@@ -133,7 +133,7 @@ A few important details:
 - Inspect `call.get_position()`, `call.get_tilt()` and `call.get_stop()` to find out what the caller actually asked
   for; only the fields the caller set will be present (`get_position()`/`get_tilt()` are `optional<float>`, so check
   `has_value()` before dereferencing).
-- `get_position()` and `get_tilt()` range from `0.0` (`COVER_CLOSED`) to `1.0` (`COVER_OPEN`) - use these constants
+- `get_position()` and `get_tilt()` range from `0.0` (`cover::COVER_CLOSED`) to `1.0` (`cover::COVER_OPEN`) - use these constants
   rather than the raw literals where it improves readability.
 - After driving the hardware, update `this->position` (and `this->tilt`, if supported) and set `this->current_operation`
   before calling `publish_state()`, so the front-end sees an accurate, up-to-date state.
@@ -150,10 +150,10 @@ controls rather than trusting the reported position as ground truth.
 
 ### Useful members
 
-- `position`: the current reported position, `0.0` (closed) to `1.0` (open). Use `COVER_OPEN` / `COVER_CLOSED` for the
+- `position`: the current reported position, `0.0` (closed) to `1.0` (open). Use `cover::COVER_OPEN` / `cover::COVER_CLOSED` for the
   extremes.
 - `tilt`: the current reported tilt, on the same `0.0`-`1.0` scale.
-- `current_operation`: one of `COVER_OPERATION_IDLE`, `COVER_OPERATION_OPENING`, `COVER_OPERATION_CLOSING`.
+- `current_operation`: one of `cover::COVER_OPERATION_IDLE`, `cover::COVER_OPERATION_OPENING`, `cover::COVER_OPERATION_CLOSING`.
 - `is_fully_open()` / `is_fully_closed()`: convenience helpers comparing `position` against `1.0` / `0.0`.
 - `publish_state(bool save = true)`: report the current `position`/`tilt`/`current_operation` to the front-end; pass
   `save = false` to skip persisting the state to flash.

--- a/src/content/docs/architecture/components/display.md
+++ b/src/content/docs/architecture/components/display.md
@@ -2,4 +2,146 @@
 title: "Display"
 ---
 
+Unlike [sensor](/architecture/components/sensor) or [switch](/architecture/components/switch), `display` is not a
+Home Assistant entity type - it does not appear as a device in the front-end. Instead it is a hardware/utility base
+that drives a screen: an OLED, an e-paper panel, a TFT, and so on. Other parts of ESPHome (fonts, images, graphs, the
+`graphical_display_menu`, and most importantly the user's own `lambda`) draw onto a `display` instance; the platform's
+job is to get whatever was drawn onto the physical screen.
 
+Like the entity types, `display` is a *platform* base: individual components (for example `ssd1306_i2c`, `ili9xxx` or
+`waveshare_epaper`) register a display and implement the code that talks to the actual controller chip.
+
+## Python
+
+A display platform lives in a `display.py` file (or a `display/__init__.py` package) inside your component's
+directory, allowing the user to configure it under the top-level `display:` block:
+
+```yaml
+display:
+  - platform: my_component
+    lambda: |-
+      it.print(0, 0, id(my_font), "Hello World!");
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import display
+
+my_display_ns = cg.esphome_ns.namespace("my_display")
+MyDisplay = my_display_ns.class_("MyDisplay", cg.PollingComponent, display.DisplayBuffer)
+```
+
+Most display drivers buffer a full frame in RAM and inherit `display.DisplayBuffer`, which itself extends the base
+`display.Display` (which extends `cg.PollingComponent`). A handful of displays that don't need a RAM buffer (for
+example ones that stream draw commands straight to the controller) inherit `display.Display` directly instead.
+
+### Configuration schema
+
+Rather than a single `<platform>_schema()` helper, `display` provides two schema building blocks that you extend:
+`display.BASIC_DISPLAY_SCHEMA` (just the `lambda` option plus `update_interval`) and `display.FULL_DISPLAY_SCHEMA`,
+which additionally adds `rotation`, `pages`, `on_page_change`, `auto_clear_enabled` and `show_test_card`. Most drivers
+extend the full schema with their own hardware-specific options:
+
+```python
+CONFIG_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(MyDisplay),
+        cv.Optional(cv.CONF_RESET_PIN): pins.gpio_output_pin_schema,
+    }
+).extend(cv.polling_component_schema("1s"))
+```
+
+You need an explicit `cv.GenerateID()` / `cv.declare_id()` here since, unlike `sensor.sensor_schema()`, the display
+schema helpers don't take your class as an argument.
+
+### Code generation
+
+In `to_code`, register the display with `display.register_display()`. This calls `cg.register_component()` for you
+*and* generates the code for all of the common options - `rotation`, `pages`, the `lambda`, and so on:
+
+```python
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await display.register_display(var, config)
+
+    if reset_pin := config.get(CONF_RESET_PIN):
+        pin = await cg.gpio_pin_expression(reset_pin)
+        cg.add(var.set_reset_pin(pin))
+```
+
+If your driver accepts a `lambda:` that isn't handled by `register_display` (uncommon - most drivers just let the
+full schema deal with it), process it with `cg.process_lambda()` and pass `display.DisplayRef` as the lambda's
+parameter type so the user's lambda receives `it` as a `display::Display &`.
+
+## C++
+
+The C++ class inherits from `display::DisplayBuffer` (or `display::Display` directly, for unbuffered drivers). Note
+that `DisplayBuffer`/`Display` already inherit `PollingComponent`, so you don't add a separate component base:
+
+```cpp
+#include "esphome/components/display/display_buffer.h"
+
+namespace esphome::my_display {
+
+class MyDisplay : public display::DisplayBuffer {
+ public:
+  void setup() override;
+  void update() override;
+  void dump_config() override;
+
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+
+ protected:
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  int get_width_internal() override { return 128; }
+  int get_height_internal() override { return 64; }
+};
+
+}  // namespace esphome::my_display
+```
+
+### The draw / update flow
+
+Whatever draws onto the display - the user's `lambda:`, a configured `pages:` entry, fonts, images - ultimately calls
+the public `draw_pixel_at(x, y, color)` (or one of the higher-level helpers like `line()`, `filled_rectangle()`,
+`print()`, etc., which are all implemented in terms of it). `DisplayBuffer` applies clipping and the configured
+`rotation:` and then calls the one method you must implement: `draw_absolute_pixel_internal(x, y, color)`, which
+writes a single pixel into your driver's own frame buffer.
+
+Because `Display` inherits `PollingComponent`, your driver's `update()` is called on the user's `update_interval:`.
+This is where you actually refresh the screen:
+
+```cpp
+void MyDisplay::update() {
+  // Runs the configured lambda/pages against this display, filling the buffer.
+  this->do_update_();
+  // Push the now-updated buffer out to the physical hardware.
+  this->write_display_data_();
+}
+```
+
+`do_update_()` (protected, on the base class) clears the buffer if `auto_clear_enabled:` is set, then invokes either
+the active `DisplayPage`'s writer or the top-level `lambda:` - both receive `*this` as their `it` argument - and
+finally clears the clipping region. None of that touches real hardware; it only updates your in-memory buffer, so
+your `update()` implementation is responsible for flushing that buffer out over I2C/SPI/etc. afterwards.
+
+Allocate your buffer during `setup()` with the base class's `init_internal_(buffer_length)`, sized appropriately for
+your pixel format (for example `width * height / 8` for a 1-bit-per-pixel panel).
+
+### Useful members
+
+- `get_width()` / `get_height()`: the *rotated* dimensions as seen by drawing code (call your own
+  `get_width_internal()` / `get_height_internal()` for the native, pre-rotation dimensions).
+- `fill(Color)` / `clear()`: fill the whole buffer with a color (or `COLOR_OFF`). The default implementation walks
+  every pixel via `draw_absolute_pixel_internal()`; override `fill()` if your hardware/buffer layout allows a faster
+  bulk clear.
+- `get_display_type()`: must return `DISPLAY_TYPE_BINARY`, `DISPLAY_TYPE_GRAYSCALE` or `DISPLAY_TYPE_COLOR` so other
+  components (like `image`) know how to render content for your panel.
+- `LOG_DISPLAY(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the rotation and dimensions in
+  the standard format.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/display.md
+++ b/src/content/docs/architecture/components/display.md
@@ -28,7 +28,9 @@ The typical imports and class declaration look like this:
 ```python
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome import pins
 from esphome.components import display
+from esphome.const import CONF_RESET_PIN
 
 my_display_ns = cg.esphome_ns.namespace("my_display")
 MyDisplay = my_display_ns.class_("MyDisplay", cg.PollingComponent, display.DisplayBuffer)
@@ -49,7 +51,7 @@ extend the full schema with their own hardware-specific options:
 CONFIG_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(MyDisplay),
-        cv.Optional(cv.CONF_RESET_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
     }
 ).extend(cv.polling_component_schema("1s"))
 ```

--- a/src/content/docs/architecture/components/event.md
+++ b/src/content/docs/architecture/components/event.md
@@ -2,4 +2,232 @@
 title: "Event"
 ---
 
+The `event` component is one of ESPHome's core [entity](/architecture/components/index) types. An event is
+*stateless*: rather than tracking a value like a [sensor](/architecture/components/sensor) does, it simply fires
+discrete, named occurrences - a doorbell press, a remote's "long press" action, a button's double-click. The
+front-end never commands an event; there is nothing to turn on or set. Your component calls `trigger()` whenever the
+real-world occurrence happens, and the entity briefly reports "this named event just happened" to the front-end.
 
+This makes `event` different from both a [binary sensor](/architecture/components/binary_sensor) (which has a
+persistent ON/OFF state) and a [sensor](/architecture/components/sensor) (which has a persistent numeric state): an
+event has no ongoing state to query beyond "what was the last event type, and when."
+
+Like the other entity types, `event` is a *platform* base. Individual components (for example `uart` or a physical
+button driver) register an event and call `trigger()` with one of a fixed set of event type strings whenever
+something happens.
+
+## Python
+
+An event platform lives in an `event.py` file (or an `event/__init__.py` package) inside your component's directory.
+This file name tells ESPHome that the component provides an `event` platform, allowing the user to configure it
+under the `event:` block:
+
+```yaml
+event:
+  - platform: my_component
+    name: "My Button"
+    event_types:
+      - "single_press"
+      - "double_press"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import event
+
+my_event_ns = cg.esphome_ns.namespace("my_event")
+MyEvent = my_event_ns.class_("MyEvent", event.Event, cg.Component)
+```
+
+Note that `MyEvent` inherits from both `event.Event` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+Use the `event.event_schema()` helper. It returns a schema pre-populated with the options common to every event -
+`name`, `id`, `icon`, `entity_category`, `device_class` and the `on_event` automation - and lets you pass defaults
+for your device:
+
+```python
+CONFIG_SCHEMA = event.event_schema(MyEvent).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyEvent`) as the first argument tells the helper which class to declare the ID for, so you do
+not need a separate `cv.GenerateID()`. Unlike `sensor_schema()`, `event_schema()` does not take the list of event
+types your device supports - that is application-specific, so components typically declare their own
+`CONF_EVENT_TYPES` option (or hard-code the list) and pass it separately to `new_event()`.
+
+### Code generation
+
+In `to_code`, use the `event.new_event()` helper, passing the list of event type strings the entity supports as the
+`event_types` keyword argument. It calls `cg.new_Pvariable()` for you *and* generates the code to register those
+event types and apply the common options from the configuration:
+
+```python
+async def to_code(config):
+    var = await event.new_event(config, event_types=["single_press", "double_press"])
+    await cg.register_component(var, config)
+```
+
+If your component owns an event as a child (rather than *being* an event), use
+`await event.register_event(var, config, event_types=[...])` instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `event::Event` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/event/event.h"
+
+namespace esphome::my_event {
+
+class MyEvent : public event::Event, public Component {
+ public:
+  void loop() override;
+};
+
+}  // namespace esphome::my_event
+```
+
+### Firing events
+
+`event::Event` is emit-only: there is no `control()` to override and nothing for the front-end to command. Your only
+job is to call `trigger()` with one of the configured event type strings whenever the real-world occurrence happens:
+
+```cpp
+void MyEvent::loop() {
+  if (this->button_was_pressed_()) {
+    this->trigger("single_press");
+  }
+}
+```
+
+`trigger()` validates that the given string is one of the event types registered via `set_event_types()`, stores it
+as the "last event type", and notifies the front-end. If the string does not match a registered type, it logs an
+error and does nothing - so the strings you pass to `trigger()` must exactly match the `event_types` you supplied in
+Python.
+
+### Useful members
+
+- `trigger(const std::string &event_type)`: fires the named event, notifying the front-end.
+- `get_last_event_type()`: returns the most recently triggered event type as a `StringRef`, or an empty one if
+  nothing has fired yet.
+- `has_event()`: whether any event has been triggered since boot.
+- `get_event_types()`: the list of event type strings this entity supports.
+- `LOG_EVENT(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the event's name, icon and
+  device class in the standard format.
+
+## Exposing multiple events from one component
+
+Hardware often has more than one thing that can fire an event - a remote with several buttons, or a keypad hub with
+one event entity per physical key. There are two established ways to model this. Both are valid and both are widely
+used in-tree - which one fits depends on how the hardware itself is shaped, so read the two together and pick the one
+that describes your device more honestly.
+
+### A hub plus a `type` on the platform
+
+With a top-level hub already configured, add one `event:` entry per button, distinguished by `type`, via
+`cv.typed_schema()` with `key=CONF_TYPE`. Since `event_schema()` does not carry `event_types` (that stays a separate
+keyword argument to `new_event()`), keep a small lookup so each button gets the right list:
+
+```yaml
+remote_hub:
+  id: the_remote
+
+event:
+  - platform: remote_hub
+    type: button_1
+    name: "Button 1"
+  - platform: remote_hub
+    type: button_2
+    name: "Button 2"
+```
+
+```python
+from esphome.const import CONF_TYPE
+from .. import CONF_REMOTE_HUB_ID, RemoteHub, RemoteHubButtonEvent
+
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_REMOTE_HUB_ID): cv.use_id(RemoteHub)})
+_EVENT_TYPES = {
+    "button_1": ["single_press", "double_press", "long_press"],
+    "button_2": ["single_press", "double_press"],
+}
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "button_1": event.event_schema(RemoteHubButtonEvent).extend(_HUB_ID_SCHEMA),
+        "button_2": event.event_schema(RemoteHubButtonEvent).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+async def to_code(config):
+    var = await event.new_event(config, event_types=_EVENT_TYPES[config[CONF_TYPE]])
+    await cg.register_component(var, config)
+    await cg.register_parented(var, config[CONF_REMOTE_HUB_ID])
+```
+
+`cv.typed_schema()` puts the matched key back into `config[CONF_TYPE]`, so `to_code` can look up the right
+`event_types` for this entry. Each button is a first-class platform entry with the full option set, and adding
+another button later is purely additive.
+
+### Sub-configs on a single platform entry
+
+Some components instead nest each button as an optional sub-key under one platform entry (`button_1:`, `button_2:`
+under a single `- platform: remote_hub`), each an inline `event_schema()` called without a class argument - just
+like `sensor_schema()`, `event_schema()` accepts being called with no class. `event_types` still has to be supplied
+explicitly per button when calling `new_event()`:
+
+```python
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(RemoteHub),
+        cv.Optional("button_1"): event.event_schema(),
+        cv.Optional("button_2"): event.event_schema(),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    if button_1_config := config.get("button_1"):
+        types = ["single_press", "double_press", "long_press"]
+        evt = await event.new_event(button_1_config, event_types=types)
+        cg.add(var.set_button_1_event(evt))
+```
+
+No `SUB_EVENT` macro exists, so declare the pointer members and setters by hand, and null-check them before calling
+`trigger()` - the user may configure only some of the buttons:
+
+```cpp
+class RemoteHub : public Component {
+ public:
+  void set_button_1_event(event::Event *e) { this->button_1_event_ = e; }
+  void set_button_2_event(event::Event *e) { this->button_2_event_ = e; }
+ protected:
+  event::Event *button_1_event_{nullptr};
+  event::Event *button_2_event_{nullptr};
+};
+```
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device
+and its buttons, so let the hardware decide:
+
+- **Sub-configs** fit when the buttons are facets of one inseparable set that a single remote or keypad exposes
+  together. A small, fixed set of buttons read from a single transaction mirrors what the device actually reports, and
+  keeps one physical device to one YAML block, which is easier to read.
+- **A hub plus `type`** fits when the buttons are genuinely independent things that happen to share a connection. If a
+  hub component already exists because the device or transport must be configured once and shared, then each button
+  being its own entry is the more natural fit - especially when the set is large or open-ended, or when different
+  buttons need different event types or update strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses.
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component) for a fully worked example of both patterns.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/fan.md
+++ b/src/content/docs/architecture/components/fan.md
@@ -2,4 +2,249 @@
 title: "Fan"
 ---
 
+The `fan` component is one of ESPHome's core [entity](/architecture/components/index) types. A fan represents a
+device that can be turned on/off and, depending on the hardware, may also support variable speed, oscillation, a
+configurable direction and named preset modes. Unlike a [switch](/architecture/components/switch), a fan's state is
+made up of several independent properties that the front-end (Home Assistant, the web server, MQTT, etc.) can set
+together or individually.
 
+Like the other entity types, `fan` is a *platform* base. Individual components (for example `template`, `speed` or a
+relay-driven fan) register a fan and implement the logic that actually drives the hardware.
+
+We have an [example, minimal fan component](https://github.com/esphome/starter-components/tree/main/components/empty_fan)
+which is a good starting point.
+
+## Python
+
+A fan platform lives in a `fan.py` file (or a `fan/__init__.py` package) inside your component's directory. This file
+name tells ESPHome that the component provides a `fan` platform, allowing the user to configure it under the `fan:`
+block:
+
+```yaml
+fan:
+  - platform: my_component
+    name: "My Fan"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import fan
+
+my_fan_ns = cg.esphome_ns.namespace("my_fan")
+MyFan = my_fan_ns.class_("MyFan", fan.Fan, cg.Component)
+```
+
+Note that `MyFan` inherits from both `fan.Fan` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+Use the `fan.fan_schema()` helper. It returns a schema pre-populated with all of the options common to every fan -
+`name`, `id`, `icon`, `restore_mode`, `entity_category`, the `on_state` / `on_turn_on` / `on_turn_off` / `on_speed_set`
+/ `on_oscillating_set` / `on_direction_set` / `on_preset_set` automations, and so on - and lets you pass defaults for
+your device:
+
+```python
+CONFIG_SCHEMA = fan.fan_schema(MyFan).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyFan`) as the first argument tells the helper which class to declare the ID for, so you do not
+need a separate `cv.GenerateID()`.
+
+### Code generation
+
+In `to_code`, use the `fan.new_fan()` helper. It calls `cg.new_Pvariable()` for you *and* generates all the code to
+apply the common fan options from the configuration:
+
+```python
+async def to_code(config):
+    var = await fan.new_fan(config)
+    await cg.register_component(var, config)
+```
+
+If your component owns a fan as a child (rather than *being* a fan), use `await fan.register_fan(var, config)` instead,
+having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `fan::Fan` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/fan/fan.h"
+
+namespace esphome::my_fan {
+
+class MyFan : public fan::Fan, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+  fan::FanTraits get_traits() override { return this->traits_; }
+
+ protected:
+  void control(const fan::FanCall &call) override;
+
+  fan::FanTraits traits_;
+};
+
+}  // namespace esphome::my_fan
+```
+
+### Declaring traits
+
+`get_traits()` tells the front-end what the fan supports. `FanTraits` is usually built once (in `setup()`, or lazily
+in `get_traits()`) from a small set of booleans plus the number of discrete speed levels:
+
+```cpp
+void MyFan::setup() {
+  // oscillation, speed, direction, speed_count
+  this->traits_ = fan::FanTraits(this->has_oscillating_, this->speed_count_ > 0, this->has_direction_,
+                                  this->speed_count_);
+}
+```
+
+If your fan supports named preset modes (e.g. "Sleep", "Auto"), call `set_supported_preset_modes()` on the *fan
+entity itself* (not on the traits) and wire the pointer into the traits you return:
+
+```cpp
+fan::FanTraits MyFan::get_traits() {
+  this->wire_preset_modes_(this->traits_);
+  return this->traits_;
+}
+```
+
+### Handling commands with `FanCall`
+
+The one method you *must* implement is `control()`. It is called whenever the front-end (or an automation, via
+`fan.turn_on`/`fan.turn_off`/`fan.toggle`) wants to change one or more properties of the fan. Rather than a single
+value like `switch::Switch::write_state(bool)`, you are given a `FanCall` - a builder object where each property is an
+`optional<T>` that is only present if the caller actually asked to change it:
+
+```cpp
+void MyFan::control(const fan::FanCall &call) {
+  if (call.get_state().has_value())
+    this->state = *call.get_state();
+  if (call.get_speed().has_value())
+    this->speed = *call.get_speed();
+  if (call.get_oscillating().has_value())
+    this->oscillating = *call.get_oscillating();
+  if (call.get_direction().has_value())
+    this->direction = *call.get_direction();
+  this->apply_preset_mode_(call);
+
+  // Drive the hardware here, based on this->state / this->speed / ...
+
+  this->publish_state();
+}
+```
+
+A few important details:
+
+- Only apply a field if `has_value()` is true - a `FanCall` that only sets `speed` should not silently turn the fan on
+  or off.
+- `apply_preset_mode_(call)` is a protected helper on `Fan` that looks up `call.get_preset_mode()` against the
+  supported preset modes and stores it for you; use it instead of handling preset mode by hand.
+- Drive the hardware, then call `publish_state()` (no arguments - it republishes whatever is currently stored on
+  `state`, `speed`, `oscillating`, `direction` and the preset mode) to report the *actually achieved* state back to
+  the front-end.
+
+### `make_call()`
+
+Code elsewhere in ESPHome (actions, other components, or your own `setup()` when restoring state) never calls
+`control()` directly. Instead it builds a `FanCall` via `make_call()` (or the shorthand `turn_on()` / `turn_off()` /
+`toggle()`) and calls `perform()`, which validates the requested values against `get_traits()` and then dispatches to
+your `control()`:
+
+```cpp
+id(my_fan).make_call().set_state(true).set_speed(3).perform();
+```
+
+### Useful members
+
+- `state` / `speed` / `oscillating` / `direction`: the current reported values, kept in sync by `publish_state()`.
+- `has_preset_mode()` / `get_preset_mode()`: whether a preset mode is currently active, and its name.
+- `FanDirection`: enum with `FORWARD` and `REVERSE`.
+- `LOG_FAN(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the fan and its traits in the
+  standard format.
+
+## Exposing multiple fans from one component
+
+Hardware sometimes drives more than one fan from a single controller - a multi-fan controller hub might expose one
+fan per header, and not every header is necessarily the same kind (for example one PWM header with variable speed,
+and one relay header that only supports on/off). There are two established ways to model this. Both are valid and
+both are widely used in-tree - which one fits depends on how the hardware itself is shaped, so read the two together
+and pick the one that describes your device more honestly.
+
+### A hub plus a `type` on the platform
+
+If your component has a top-level hub, let the user add *one `fan:` entry per header*, distinguished by a `type`
+key, using `cv.typed_schema()` with `key=CONF_TYPE`:
+
+```yaml
+my_hub:
+  id: the_hub
+fan:
+  - platform: my_hub
+    type: pwm
+    name: "Case Fan"
+  - platform: my_hub
+    type: relay
+    name: "Exhaust Fan"
+```
+
+```python
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_MY_HUB_ID): cv.use_id(MyHub)})
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "pwm": fan.fan_schema(MyHubPwmFan).extend(_HUB_ID_SCHEMA),
+        "relay": fan.fan_schema(MyHubRelayFan).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+async def to_code(config):
+    var = await fan.new_fan(config)
+    await cg.register_component(var, config)
+    await cg.register_parented(var, config[CONF_MY_HUB_ID])
+```
+
+Each `type` gets its own schema and C++ class - the PWM header and the relay header return different `FanTraits`
+from `get_traits()` - and adding a third type later is purely additive. See
+[Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component)
+for a fully worked example.
+
+### Sub-configs on a single platform entry
+
+Some components instead nest their headers as optional sub-keys under one platform entry, the way
+[`dht`](https://github.com/esphome/esphome/tree/dev/esphome/components/dht) nests `temperature:` and `humidity:`
+under one `sensor:` entry. There is no `SUB_FAN` macro (only `binary_sensor`, `button`, `number`, `select`,
+`sensor`, `switch`, `text_sensor` have one), and unlike `sensor.sensor_schema()`, `fan.fan_schema()` always requires
+a class argument. Declare the pointer member and setter by hand, and null-check before use:
+
+```cpp
+class MyHubComponent : public Component {
+ public:
+  void set_header_0_fan(fan::Fan *fan) { this->header_0_fan_ = fan; }
+ protected:
+  fan::Fan *header_0_fan_{nullptr};
+};
+```
+
+### Choosing between them
+
+Neither pattern is deprecated; they express different relationships between a controller and the fans it drives, so
+let the hardware decide:
+
+- **Sub-configs** fit when the headers are a small, fixed set on a single controller board - one physical device
+  maps to one YAML block, which is easier to read.
+- **A hub plus `type`** fits when a hub component already exists to describe the connection, and the set of headers
+  is large or open-ended, or different headers need different traits or C++ classes.
+
+If both descriptions fit equally well, follow whichever pattern the surrounding component already uses. In a new
+component with no hub, sub-configs are usually the smaller change.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/index.md
+++ b/src/content/docs/architecture/components/index.md
@@ -192,6 +192,19 @@ any other components and potentially fail the validation stage if an important d
 For example, many components that rely on `uart` can use the `FINAL_VALIDATE_SCHEMA` to ensure that the `tx_pin` and/or
 `rx_pin` are configured.
 
+### Exposing multiple entities
+
+Hardware frequently maps to more than one entity: a temperature/humidity sensor exposes two readings, a relay board
+exposes several switches, a multi-zone controller exposes a climate entity per zone. ESPHome has two established ways to
+model this, both valid and both common in-tree. One nests the entities as optional sub-configs under a single platform
+entry; the other, useful where a top-level hub component already exists, gives each entity its own platform entry
+distinguished by a `type` key (via `cv.typed_schema()`). Which one fits depends on whether the entities are facets of a
+single measurement cycle or independent things sharing a connection.
+
+Both patterns are worked through in full, with real in-tree examples, in
+[Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component).
+The entity-type pages in the navigation tree each describe the equivalent for their own type.
+
 ## C++ component structure
 
 Given the example Python code above, let's consider the following C++ code:

--- a/src/content/docs/architecture/components/light.md
+++ b/src/content/docs/architecture/components/light.md
@@ -2,4 +2,306 @@
 title: "Light"
 ---
 
+The `light` component is one of ESPHome's core [entity](/architecture/components/index) types. A light represents a
+device that can be turned on/off and, depending on the hardware, may also support brightness, color temperature, RGB
+color or addressable effects.
 
+`light` works differently from the other entity types. For a [sensor](/architecture/components/sensor) or a
+[switch](/architecture/components/switch), your platform class *is* the entity. For a light, the entity itself is
+`light::LightState` - a class provided entirely by ESPHome core, which handles transitions, flashes, effects and
+publishing to the front-end. Your platform instead implements `light::LightOutput`, a small interface that only knows
+how to report what the hardware supports and how to write a given color/brightness to it. `LightState` owns your
+`LightOutput` and drives it.
+
+We have an [example, minimal light component](https://github.com/esphome/starter-components/tree/main/components/empty_light)
+which is a good starting point.
+
+## Python
+
+A light platform lives in a `light.py` file (or a `light/__init__.py` package) inside your component's directory. This
+file name tells ESPHome that the component provides a `light` platform, allowing the user to configure it under the
+`light:` block:
+
+```yaml
+light:
+  - platform: my_component
+    name: "My Light"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import light
+
+my_light_ns = cg.esphome_ns.namespace("my_light")
+MyLightOutput = my_light_ns.class_("MyLightOutput", light.LightOutput)
+```
+
+Note that `MyLightOutput` inherits only from `light.LightOutput` - not from a component base. `LightState` (the
+entity) is registered as the `Component` on your behalf; your output only needs `cg.Component` in addition if it has
+its own initialization to perform (see [Optional `Component` behaviour](#optional-component-behaviour) below).
+
+### Configuration schema
+
+Use the `light.light_schema()` helper, passing your output class and the kind of light you're implementing via
+`type_=`:
+
+```python
+from esphome.components.light import LightType
+
+CONFIG_SCHEMA = light.light_schema(MyLightOutput, type_=LightType.RGB)
+```
+
+`LightType` is an enum with four members - `BINARY`, `BRIGHTNESS_ONLY`, `RGB` and `ADDRESSABLE` - and picks which of
+the underlying schemas (`BINARY_LIGHT_SCHEMA`, `BRIGHTNESS_ONLY_LIGHT_SCHEMA`, `RGB_LIGHT_SCHEMA` or
+`ADDRESSABLE_LIGHT_SCHEMA`) your platform extends, which in turn determines which options are available (for example
+`gamma_correct` and `default_transition_length` only apply from `BRIGHTNESS_ONLY` upwards, and `color_correct` /
+`power_supply` only apply to `ADDRESSABLE`) and which class of effects (`BINARY_EFFECTS`, `MONOCHROMATIC_EFFECTS`,
+`RGB_EFFECTS`, `ADDRESSABLE_EFFECTS`) are valid under `effects:`.
+
+Unlike `sensor.sensor_schema()` or `switch.switch_schema()`, the generated ID is declared under `CONF_OUTPUT_ID`, not
+`CONF_ID` - the `id:` the user sets on a light refers to the `LightState`, whose ID is already declared by the base
+schema. Your own output object gets its own, separate generated ID:
+
+```python
+CONFIG_SCHEMA = light.light_schema(MyLightOutput, type_=LightType.RGB).extend(
+    {
+        cv.Required(CONF_RED): cv.use_id(output.FloatOutput),
+        cv.Required(CONF_GREEN): cv.use_id(output.FloatOutput),
+        cv.Required(CONF_BLUE): cv.use_id(output.FloatOutput),
+    }
+)
+```
+
+If you don't need `light_schema()`'s convenience defaults (`entity_category`, `icon`, `default_restore_mode`), you can
+instead extend the underlying schema constant directly and declare the output ID yourself, as several in-tree
+components do:
+
+```python
+CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(
+    {
+        cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(MyLightOutput),
+        ...
+    }
+)
+```
+
+### Code generation
+
+In `to_code`, use the `light.new_light()` helper. It creates your output `Pvariable`, then internally creates and
+registers the `LightState` that wraps it:
+
+```python
+async def to_code(config):
+    var = await light.new_light(config)
+    red = await cg.get_variable(config[CONF_RED])
+    cg.add(var.set_red(red))
+    ...
+```
+
+If your output class also inherits `cg.Component` (see below), construct it yourself with `cg.new_Pvariable()`,
+register it as a component, and call `await light.register_light(var, config)` instead of `new_light()`:
+
+```python
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
+    await cg.register_component(var, config)
+    await light.register_light(var, config)
+```
+
+## C++
+
+The C++ class implements `light::LightOutput`:
+
+```cpp
+#include "esphome/components/light/light_output.h"
+#include "esphome/components/output/float_output.h"
+
+namespace esphome::my_light {
+
+class MyLightOutput : public light::LightOutput {
+ public:
+  void set_red(output::FloatOutput *red) { this->red_ = red; }
+  void set_green(output::FloatOutput *green) { this->green_ = green; }
+  void set_blue(output::FloatOutput *blue) { this->blue_ = blue; }
+
+  light::LightTraits get_traits() override {
+    auto traits = light::LightTraits();
+    traits.set_supported_color_modes({light::ColorMode::RGB});
+    return traits;
+  }
+
+  void write_state(light::LightState *state) override {
+    float red, green, blue;
+    state->current_values_as_rgb(&red, &green, &blue);
+    this->red_->set_level(red);
+    this->green_->set_level(green);
+    this->blue_->set_level(blue);
+  }
+
+ protected:
+  output::FloatOutput *red_;
+  output::FloatOutput *green_;
+  output::FloatOutput *blue_;
+};
+
+}  // namespace esphome::my_light
+```
+
+### Declaring supported color modes
+
+`get_traits()` tells `LightState` what your hardware can do. Call `set_supported_color_modes()` with one or more
+`ColorMode` values:
+
+- `ON_OFF`: on/off only, no dimming.
+- `BRIGHTNESS`: dimmable, single channel.
+- `WHITE`: a separate white channel (used together with another color mode, e.g. `RGB_WHITE`).
+- `COLOR_TEMPERATURE`: dimmable white with adjustable color temperature (also set `set_min_mireds()` /
+  `set_max_mireds()`).
+- `COLD_WARM_WHITE`: independently dimmable cold/warm white channels.
+- `RGB`: red/green/blue with a shared brightness.
+- `RGB_WHITE`, `RGB_COLOR_TEMPERATURE`, `RGB_COLD_WARM_WHITE`: RGB combined with a white channel.
+
+Each `ColorMode` is really a bitmask of `ColorCapability` flags (`ON_OFF`, `BRIGHTNESS`, `WHITE`,
+`COLOR_TEMPERATURE`, `COLD_WARM_WHITE`, `RGB`); if a light supports switching between several distinct modes (for
+example plain RGB *and* a separate color-temperature white channel), pass more than one `ColorMode` to
+`set_supported_color_modes()`.
+
+### Writing state to hardware
+
+The one method you *must* implement is `write_state(LightState *state)`. It is called from `loop()` by the light core
+every time the *current* (post-transition) values have changed, and you should push them to hardware immediately.
+Unlike a switch or fan, you never call `publish_state()` yourself - `LightState` owns the state and publishing.
+
+Read the values you need through `state->current_values_as_*()`, not the raw `state->current_values` fields directly:
+these accessors apply gamma correction and convert the internal, mode-specific representation into the shape your
+hardware expects:
+
+- `current_values_as_binary(bool *binary)`
+- `current_values_as_brightness(float *brightness)`
+- `current_values_as_rgb(float *red, float *green, float *blue)`
+- `current_values_as_rgbw(float *red, float *green, float *blue, float *white)`
+- `current_values_as_rgbww(float *red, float *green, float *blue, float *cold_white, float *warm_white)`
+- `current_values_as_rgbct(float *red, float *green, float *blue, float *color_temperature, float *white_brightness)`
+- `current_values_as_cwww(float *cold_white, float *warm_white)`
+- `current_values_as_ct(float *color_temperature, float *white_brightness)`
+
+Pick the accessor matching the `ColorMode`(s) you declared, regardless of what the user's automations set - a light in
+`COLOR_TEMPERATURE` mode should call `current_values_as_ct()`, and so on.
+
+### Optional `Component` behaviour
+
+If your output needs its own hardware initialization (for example a status LED on a raw GPIO pin), you can also
+inherit `Component` and implement `setup()`/`dump_config()` as usual - just remember to `cg.register_component()` it
+in Python in addition to `light.register_light()`, as shown above. If your output has no independent setup to do (most
+simple color outputs don't - the wrapped `output::FloatOutput`/`output::BinaryOutput` instances handle their own
+setup), skip `Component` entirely, as in the example above.
+
+Two further optional overrides exist for advanced cases:
+
+- `setup_state(LightState *state)`: called once when the `LightState` is set up; use it if you need a pointer back to
+  the state (for example to register a `LightRemoteValuesListener`).
+- `update_state(LightState *state)`: called every time the current values change, *before* `write_state()`. Every call
+  to `write_state()` is preceded by at least one call to `update_state()`, but `update_state()` can also fire on its
+  own without a following `write_state()` - useful for cheap bookkeeping that should track every change, separate from
+  the (potentially more expensive) actual hardware write.
+
+### Useful members
+
+- `ColorMode` / `ColorCapability`: the color-mode and capability enums described above.
+- `LightTraits::set_min_mireds()` / `set_max_mireds()`: the color-temperature range, required when supporting
+  `COLOR_TEMPERATURE`.
+- `create_default_transition()`: override to provide a custom `LightTransformer` for transitions; the default uses a
+  smooth (gamma-aware) transition.
+- `state->get_effect_name()`: the name of the currently active effect, or `"None"`.
+
+## Exposing multiple lights from one component
+
+Hardware sometimes drives more than one light from a single controller - an LED driver hub might expose a plain
+dimmable white channel on one header and a full RGB channel on another. Since the *entity* is always the core-owned
+`light::LightState`, exposing a light means registering a `LightOutput` and letting `light.new_light()` wrap it in
+its own `LightState`. There are still two established ways to let the user configure which outputs exist, and both
+are valid - which one fits depends on how the hardware itself is shaped.
+
+### A hub plus a `type` on the platform
+
+If your component has a top-level hub, let the user add *one `light:` entry per channel*, distinguished by a `type`
+key, using `cv.typed_schema()` with `key=CONF_TYPE`. Each type maps to that channel's real
+`light.light_schema(class_, type_=LightType.X)` call:
+
+```yaml
+my_light_hub:
+  id: the_hub
+light:
+  - platform: my_light_hub
+    type: white
+    name: "Hallway Light"
+  - platform: my_light_hub
+    type: rgb
+    name: "Accent Light"
+```
+
+```python
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_MY_HUB_ID): cv.use_id(MyHub)})
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "white": light.light_schema(MyHubWhiteLightOutput, type_=LightType.BRIGHTNESS_ONLY).extend(_HUB_ID_SCHEMA),
+        "rgb": light.light_schema(MyHubRgbLightOutput, type_=LightType.RGB).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+async def to_code(config):
+    var = await light.new_light(config)
+    await cg.register_parented(var, config[CONF_MY_HUB_ID])
+```
+
+The generated ID for each type lives under `CONF_OUTPUT_ID`, not `CONF_ID`, and `new_light()` already registers the
+`LightState` as a component, so `to_code` needs no separate `cg.register_component()` call. Each `type` gets its own
+schema, so the white channel and the RGB channel can declare both a different output class and a different
+`LightType`. See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component)
+for a fully worked example.
+
+### Sub-configs on a single platform entry
+
+Some components instead nest their channels as optional sub-keys under one platform entry, the way
+[`dht`](https://github.com/esphome/esphome/tree/dev/esphome/components/dht) nests `temperature:` and `humidity:`
+under one `sensor:` entry. This is a heavier lift for `light`: unlike `sensor.sensor_schema()`,
+`light.light_schema()` has no default for `class_` or `type_`, so every sub-config needs its own output class and
+explicit `LightType`, and `to_code` calls `light.new_light()` per configured channel:
+
+```python
+if channel_0_config := config.get(CONF_CHANNEL_0):
+    output = await light.new_light(channel_0_config)
+    cg.add(var.set_channel_0_light_output(output))
+```
+
+There is no `SUB_LIGHT` macro (only `binary_sensor`, `button`, `number`, `select`, `sensor`, `switch`, `text_sensor`
+have one), so declare the pointer member and setter by hand, and null-check before use:
+
+```cpp
+class MyHubComponent : public Component {
+ public:
+  void set_channel_0_light_output(light::LightOutput *output) { this->channel_0_light_output_ = output; }
+ protected:
+  light::LightOutput *channel_0_light_output_{nullptr};
+};
+```
+
+### Choosing between them
+
+Neither pattern is deprecated; they express different relationships between a driver and the outputs it exposes, so
+let the hardware decide:
+
+- **Sub-configs** fit a small, fixed set of channels from a single LED driver board - one physical device maps to
+  one YAML block, which is easier to read.
+- **A hub plus `type`** fits when a hub component already exists to describe the connection, and the set of channels
+  is large or open-ended, or different channels need different color modes (`LightType`) or output classes.
+
+If both descriptions fit equally well, follow whichever pattern the surrounding component already uses. In a new
+component with no hub, sub-configs are usually the smaller change.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/lock.md
+++ b/src/content/docs/architecture/components/lock.md
@@ -2,4 +2,209 @@
 title: "Lock"
 ---
 
+The `lock` component is one of ESPHome's core [entity](/architecture/components/index) types. A lock is conceptually a
+[switch](/architecture/components/switch) with a richer set of states: instead of a plain ON/OFF, it reports one of
+several `LockState` values (`LOCKED`, `UNLOCKED`, `JAMMED`, `LOCKING`, `UNLOCKING`, and optionally `OPENING`/`OPEN`), and
+in addition to locking/unlocking it can optionally support a separate "open" action to unlatch a door.
 
+Like the other entity types, `lock` is a *platform* base. Individual components (for example `template`, `copy` or an
+output-driven relay) register a lock and implement the logic that actually drives the hardware.
+
+## Python
+
+A lock platform lives in a `lock.py` file (or a `lock/__init__.py` package) inside your component's directory. This
+file name tells ESPHome that the component provides a `lock` platform, allowing the user to configure it under the
+`lock:` block:
+
+```yaml
+lock:
+  - platform: my_component
+    name: "My Lock"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import lock
+
+my_lock_ns = cg.esphome_ns.namespace("my_lock")
+MyLock = my_lock_ns.class_("MyLock", lock.Lock, cg.Component)
+```
+
+Note that `MyLock` inherits from both `lock.Lock` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+Use the `lock.lock_schema()` helper. It returns a schema pre-populated with all of the options common to every lock -
+`name`, `id`, `icon`, `entity_category`, the `on_lock` / `on_unlock` automations, and so on - and lets you pass defaults
+for your device:
+
+```python
+CONFIG_SCHEMA = lock.lock_schema(MyLock).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyLock`) as the first argument tells the helper which class to declare the ID for, so you do not
+need a separate `cv.GenerateID()`.
+
+### Code generation
+
+In `to_code`, use the `lock.new_lock()` helper. It calls `cg.new_Pvariable()` for you *and* generates all the code to
+apply the common lock options from the configuration:
+
+```python
+async def to_code(config):
+    var = await lock.new_lock(config)
+    await cg.register_component(var, config)
+
+    cg.add(var.traits.set_supports_open(True))
+```
+
+If your component owns a lock as a child (rather than *being* a lock), use `await lock.register_lock(var, config)`
+instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `lock::Lock` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/lock/lock.h"
+
+namespace esphome::my_lock {
+
+class MyLock : public lock::Lock, public Component {
+ public:
+  void setup() override { this->traits.set_supports_open(true); }
+  void dump_config() override;
+
+ protected:
+  void control(const lock::LockCall &call) override;
+};
+
+}  // namespace esphome::my_lock
+```
+
+### Handling control calls
+
+The front-end calls the public `lock()` / `unlock()` / `open()` methods. `lock()` and `unlock()` each build a
+`LockCall` requesting the corresponding `LockState` and dispatch it to your protected virtual `control()` override,
+which is the one method you *must* implement. Read the requested state off the call, drive the hardware, and then call
+`publish_state()` yourself to report what was actually achieved:
+
+```cpp
+void MyLock::control(const lock::LockCall &call) {
+  if (!call.get_state().has_value())
+    return;
+
+  auto state = *call.get_state();
+  if (state == lock::LOCK_STATE_LOCKED) {
+    this->write_lock_hardware_();
+  } else if (state == lock::LOCK_STATE_UNLOCKED) {
+    this->write_unlock_hardware_();
+  }
+
+  this->publish_state(state);
+}
+```
+
+A few important details:
+
+- `LockCall::get_state()` returns an `optional<LockState>` - always check `has_value()` before dereferencing, since a
+  call may not carry a state change in every case.
+- You should call `publish_state()` yourself once the hardware has been driven; the base class does *not* do this for
+  you. This lets you report intermediate states (`LOCKING`/`UNLOCKING`) or a `JAMMED` failure instead of blindly
+  echoing back the requested state.
+- `open()` is handled separately: if `traits.get_supports_open()` is `true`, it calls the protected `open_latch()`
+  method (which defaults to simply calling `unlock()`) - override `open_latch()` if opening needs to do something
+  different from unlocking.
+- Only advertise support for `open()` (via `traits.set_supports_open(true)`) if your hardware genuinely has a separate
+  unlatch action.
+
+### Useful members
+
+- `state`: the current reported `LockState`.
+- `traits`: a `LockTraits` instance describing what the lock supports (`set_supports_open()`, `set_requires_code()`,
+  `set_assumed_state()`, `set_supported_states()`).
+- `make_call()`: build a `LockCall` targeting this lock, useful for issuing a control call programmatically (for
+  example from a lambda).
+- `add_on_state_callback(F &&callback)`: register a `void(LockState)` callback to run whenever the lock's state
+  changes.
+- `LOG_LOCK(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the lock in the standard format.
+
+## Exposing multiple locks from one component
+
+Hardware often controls more than one lock - a multi-door access controller, for example, might drive a front door
+lock and a back door lock over the same bus. There are two established ways to model this.
+
+### A hub plus a `type` on the platform
+
+If your component already has a top-level hub, let the user add one `lock:` entry per door, distinguished by a
+`type` key via `cv.typed_schema()`:
+
+```yaml
+lock:
+  - platform: my_hub
+    type: front_door
+    name: "Front Door"
+  - platform: my_hub
+    type: back_door
+    name: "Back Door"
+```
+
+```python
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "front_door": lock.lock_schema(MyHubLock).extend(_HUB_ID_SCHEMA),
+        "back_door": lock.lock_schema(MyHubLock).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+
+async def to_code(config):
+    var = await lock.new_lock(config)
+    await cg.register_parented(var, config[CONF_MY_HUB_ID])
+```
+
+Each door is a first-class platform entry with the full set of per-entity options, and adding a new door later is
+purely additive.
+
+### Sub-configs on a single platform entry
+
+Some components instead nest optional locks under one platform entry, each an inline
+`cv.Optional(CONF_FRONT_DOOR): lock.lock_schema()` - note `lock_schema()` called *without* a class argument. There is
+no `SUB_LOCK` macro (`SUB_*` exists only for `binary_sensor`, `button`, `number`, `select`, `sensor`, `switch` and
+`text_sensor`), so declare the pointer member and setter by hand, and null-check before controlling it since the
+user may configure only one door:
+
+```cpp
+class MyComponent final : public Component {
+ public:
+  void set_front_door_lock(lock::Lock *front_door_lock) { this->front_door_lock_ = front_door_lock; }
+
+ protected:
+  lock::Lock *front_door_lock_{nullptr};
+};
+```
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component)
+for a fully worked example of both patterns, including the matching Python schema and `to_code`.
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device
+and its locks, so let the hardware decide:
+
+- **Sub-configs** fit when the locks are a small, fixed set driven by a single device - for example one access
+  controller with a front door output and a back door output wired to the same board. This keeps one physical device
+  to one YAML block.
+- **A hub plus `type`** fits when the locks are independent things that happen to share a connection - especially
+  when a hub component already exists because the device or transport must be configured once, or when the set of
+  doors is large, open-ended, or different doors need different C++ classes or update strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses.
+In a new component with no hub, sub-configs are usually the smaller change.
+
+For everything else, the component implements the usual set of methods [as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/media_player.md
+++ b/src/content/docs/architecture/components/media_player.md
@@ -2,4 +2,260 @@
 title: "Media Player"
 ---
 
+The `media_player` component is one of ESPHome's core [entity](/architecture/components/index) types. A media player
+represents a device that can play audio - streaming a URL, playing a queued announcement, adjusting volume, and
+responding to transport commands like play/pause/stop. Unlike a [switch](/architecture/components/switch), which only
+toggles a boolean, a media player accepts a richer set of commands and reports back a small state machine (idle,
+playing, paused, announcing) rather than a single on/off value.
 
+Like the other entity types, `media_player` is a *platform* base. Individual components (for example `speaker`,
+`sendspin` or `speaker_source`) register a media player and implement the logic that actually decodes and outputs
+audio.
+
+## Python
+
+A media player platform lives in a `media_player.py` file (or a `media_player/__init__.py` package) inside your
+component's directory. This file name tells ESPHome that the component provides a `media_player` platform, allowing
+the user to configure it under the `media_player:` block:
+
+```yaml
+media_player:
+  - platform: my_component
+    name: "My Media Player"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import media_player
+
+my_media_player_ns = cg.esphome_ns.namespace("my_media_player")
+MyMediaPlayer = my_media_player_ns.class_("MyMediaPlayer", media_player.MediaPlayer, cg.Component)
+```
+
+Note that `MyMediaPlayer` inherits from both `media_player.MediaPlayer` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+Use the `media_player.media_player_schema()` helper. It returns a schema pre-populated with the options common to
+every media player - `name`, `id`, `icon`, `entity_category`, and the `on_state` / `on_idle` / `on_play` / `on_pause`
+/ `on_announcement` automations - and lets you pass defaults for your device:
+
+```python
+CONFIG_SCHEMA = media_player.media_player_schema(MyMediaPlayer).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyMediaPlayer`) as the first argument tells the helper which class to declare the ID for, so you
+do not need a separate `cv.GenerateID()`.
+
+### Code generation
+
+In `to_code`, use the `media_player.new_media_player()` helper. It calls `cg.new_Pvariable()` for you *and* generates
+all the code to apply the common media player options and callback automations from the configuration:
+
+```python
+async def to_code(config):
+    var = await media_player.new_media_player(config)
+    await cg.register_component(var, config)
+```
+
+If your component owns a media player as a child (rather than *being* a media player), use
+`await media_player.register_media_player(var, config)` instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `media_player::MediaPlayer` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/media_player/media_player.h"
+
+namespace esphome::my_media_player {
+
+class MyMediaPlayer : public media_player::MediaPlayer, public Component {
+ public:
+  media_player::MediaPlayerTraits get_traits() override;
+
+ protected:
+  void control(const media_player::MediaPlayerCall &call) override;
+};
+
+}  // namespace esphome::my_media_player
+```
+
+### Reporting supported features
+
+The base class needs to know what your device can do before the front-end will offer controls for it. Implement
+`get_traits()` and mark the optional features you support on a `MediaPlayerTraits` instance - a base set of features
+(`PLAY_MEDIA`, `STOP`, `VOLUME_SET`, `VOLUME_MUTE`, `MEDIA_ANNOUNCE`, `BROWSE_MEDIA`) is already included for you:
+
+```cpp
+media_player::MediaPlayerTraits MyMediaPlayer::get_traits() {
+  media_player::MediaPlayerTraits traits;
+  traits.set_supports_pause(true);
+  return traits;
+}
+```
+
+### Handling commands
+
+The one method you *must* implement is `control()`. The front-end builds a `MediaPlayerCall` (via `make_call()`) and
+the base class dispatches it here. A single call may carry a command, a new volume, a media URL to play, or an
+announcement flag - inspect only what is set:
+
+```cpp
+void MyMediaPlayer::control(const media_player::MediaPlayerCall &call) {
+  if (call.get_media_url().has_value()) {
+    this->play_url_(*call.get_media_url(), call.get_announcement().value_or(false));
+    this->state = media_player::MEDIA_PLAYER_STATE_PLAYING;
+  }
+
+  if (call.get_volume().has_value()) {
+    this->volume = *call.get_volume();
+    this->set_hardware_volume_(this->volume);
+  }
+
+  if (call.get_command().has_value()) {
+    switch (*call.get_command()) {
+      case media_player::MEDIA_PLAYER_COMMAND_PLAY:
+        this->resume_();
+        this->state = media_player::MEDIA_PLAYER_STATE_PLAYING;
+        break;
+      case media_player::MEDIA_PLAYER_COMMAND_PAUSE:
+        this->pause_();
+        this->state = media_player::MEDIA_PLAYER_STATE_PAUSED;
+        break;
+      case media_player::MEDIA_PLAYER_COMMAND_STOP:
+        this->stop_();
+        this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
+        break;
+      case media_player::MEDIA_PLAYER_COMMAND_MUTE:
+        this->set_muted_(true);
+        break;
+      case media_player::MEDIA_PLAYER_COMMAND_UNMUTE:
+        this->set_muted_(false);
+        break;
+      default:
+        break;
+    }
+  }
+
+  this->publish_state();
+}
+```
+
+A few important details:
+
+- `MediaPlayerCall`'s getters (`get_command()`, `get_volume()`, `get_media_url()`, `get_announcement()`) all return
+  `optional<T>`, since a single call typically only sets one or two of them.
+- Set `this->state` and/or `this->volume` yourself to reflect what actually happened, then call `publish_state()`
+  once at the end to notify the front-end. The base class does not do this for you.
+- `MediaPlayerState` also has an `ANNOUNCING` value - switch to it while playing a one-off announcement (e.g. a text
+  to speech notification) so the front-end shows the player is temporarily busy, then return to the previous state
+  once playback finishes.
+
+### Useful members
+
+- `state`: the current `MediaPlayerState` (`IDLE` / `PLAYING` / `PAUSED` / `ANNOUNCING` / `ON` / `OFF`).
+- `volume`: the current volume, `0.0` to `1.0`.
+- `publish_state()`: notifies the front-end of the current `state` and `volume`.
+- `is_muted()`: override this if your hardware can report mute state; defaults to `false`.
+
+## Exposing multiple media players from one component
+
+Hardware sometimes drives more than one audio output from a single device - a multi-room amplifier with several
+speaker outputs, or a multi-channel DAC hub with one player per output zone. There are two established ways to model
+this.
+
+### A hub plus a `type` on the platform
+
+With a top-level hub already configured, add one `media_player:` entry per output zone, distinguished by `type`, via
+`cv.typed_schema()` with `key=CONF_TYPE`:
+
+```yaml
+multiroom_amp:
+  id: the_amp
+
+media_player:
+  - platform: multiroom_amp
+    type: zone_a
+    name: "Kitchen"
+  - platform: multiroom_amp
+    type: zone_b
+    name: "Patio"
+```
+
+```python
+from esphome.const import CONF_TYPE
+from .. import CONF_MULTIROOM_AMP_ID, MultiroomAmp, MultiroomAmpZone
+
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_MULTIROOM_AMP_ID): cv.use_id(MultiroomAmp)})
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "zone_a": media_player.media_player_schema(MultiroomAmpZone).extend(_HUB_ID_SCHEMA),
+        "zone_b": media_player.media_player_schema(MultiroomAmpZone).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+async def to_code(config):
+    var = await media_player.new_media_player(config)
+    await cg.register_component(var, config)
+    await cg.register_parented(var, config[CONF_MULTIROOM_AMP_ID])
+```
+
+Each zone is a first-class platform entry with the full option set, adding another zone later is purely additive,
+and different zones can use different C++ classes if their capabilities diverge (for example one zone with a DAC
+that supports announcements, another without).
+
+### Sub-configs on a single platform entry
+
+Some components instead nest each output as an optional sub-key under one platform entry (`zone_a:`, `zone_b:` under
+a single `- platform: multiroom_amp`). Unlike `sensor_schema()`, `media_player_schema()` requires a class argument,
+so each sub-config still passes one explicitly, typically the same shared class:
+
+```python
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(MultiroomAmp),
+        cv.Optional("zone_a"): media_player.media_player_schema(MultiroomAmpZone),
+        cv.Optional("zone_b"): media_player.media_player_schema(MultiroomAmpZone),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+```
+
+No `SUB_MEDIA_PLAYER` macro exists, so declare the pointer members and setters by hand, and null-check them before
+use - the user may configure only one output:
+
+```cpp
+class MultiroomAmp : public Component {
+ public:
+  void set_zone_a_media_player(media_player::MediaPlayer *p) { this->zone_a_media_player_ = p; }
+  void set_zone_b_media_player(media_player::MediaPlayer *p) { this->zone_b_media_player_ = p; }
+ protected:
+  media_player::MediaPlayer *zone_a_media_player_{nullptr};
+  media_player::MediaPlayer *zone_b_media_player_{nullptr};
+};
+```
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device
+and its outputs, so let the hardware decide:
+
+- **Sub-configs** fit when the outputs are a small, fixed set driven by a single amplifier or DAC - for example a
+  two-channel board where both outputs are always present together. This keeps one physical device to one YAML
+  block.
+- **A hub plus `type`** fits when the outputs are independent things that happen to share a connection - especially
+  when a hub component already exists because the device or transport must be configured once, or when the set of
+  outputs is large, open-ended, or different outputs need different C++ classes or update strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses.
+In a new component with no hub, sub-configs are usually the smaller change.
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component) for a fully worked example of both patterns.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/number.md
+++ b/src/content/docs/architecture/components/number.md
@@ -2,4 +2,246 @@
 title: "Number"
 ---
 
+The `number` component is one of ESPHome's core [entity](/architecture/components/index) types. A number is a
+single floating point value, bounded by a minimum and maximum and stepped by some increment, that the user can set
+from the front-end (Home Assistant, the web server, MQTT, etc.) - think of a setpoint, a brightness limit, or a
+timeout value. It is conceptually similar to a [sensor](/architecture/components/sensor), except that it can also be
+*written to*: in addition to reporting its current value, it accepts a new target value from the front-end and drives
+some piece of hardware or internal state in response.
 
+Like the other entity types, `number` is a *platform* base. Individual components (for example a fan's `speed_count`,
+a thermostat's setpoint, or a template value) register a number and implement the logic that applies the new value.
+
+## Python
+
+A number platform lives in a `number.py` file (or a `number/__init__.py` package) inside your component's directory.
+This file name tells ESPHome that the component provides a `number` platform, allowing the user to configure it under
+the `number:` block:
+
+```yaml
+number:
+  - platform: my_component
+    name: "My Number"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import number
+
+my_number_ns = cg.esphome_ns.namespace("my_number")
+MyNumber = my_number_ns.class_("MyNumber", number.Number, cg.Component)
+```
+
+Note that `MyNumber` inherits from both `number.Number` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+Use the `number.number_schema()` helper. It returns a schema pre-populated with all of the options common to every
+number - `name`, `id`, `icon`, `entity_category`, `device_class`, `unit_of_measurement`, the `on_value` /
+`on_value_range` automations, and so on:
+
+```python
+CONFIG_SCHEMA = number.number_schema(MyNumber).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyNumber`) as the first argument tells the helper which class to declare the ID for, so you do
+not need a separate `cv.GenerateID()`. Unlike `sensor.sensor_schema()`, `number.number_schema()` does *not* take
+`min_value`, `max_value` or `step` arguments - those bounds are supplied later, when the number is actually
+instantiated in `to_code`, since they often depend on the specific device or hardware capability rather than being
+fixed for the whole platform.
+
+### Code generation
+
+In `to_code`, use the `number.new_number()` helper. It calls `cg.new_Pvariable()` for you *and* generates all the code
+to apply the common number options from the configuration. Because the schema does not carry the value bounds, you
+must supply `min_value`, `max_value` and `step` as keyword arguments here:
+
+```python
+async def to_code(config):
+    var = await number.new_number(config, min_value=0.0, max_value=100.0, step=1.0)
+    await cg.register_component(var, config)
+```
+
+If your component owns a number as a child (rather than *being* a number), use
+`await number.register_number(var, config, min_value=..., max_value=..., step=...)` instead, having declared the ID
+yourself.
+
+## C++
+
+The C++ class inherits from `number::Number` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome::my_number {
+
+class MyNumber : public number::Number, public Component {
+ public:
+  void dump_config() override;
+
+ protected:
+  void control(float value) override;
+};
+
+}  // namespace esphome::my_number
+```
+
+### Handling the new value
+
+The one method you *must* implement is `control()`. It is called by the front-end when the user (or an automation)
+sets a new value. Your implementation drives the hardware and then calls `publish_state()` to acknowledge the value
+that was actually applied:
+
+```cpp
+void MyNumber::control(float value) {
+  // Drive the hardware here (send a command, store a setting, etc.)
+  this->write_hardware_(value);
+
+  // Acknowledge the new value back to the front-end.
+  this->publish_state(value);
+}
+```
+
+A few important details:
+
+- `control()` is only called with a value that has already been validated against the configured `min_value:`,
+  `max_value:` and `step:` bounds, so you do not need to re-validate it yourself.
+- You should call `publish_state()` yourself once the hardware has been driven; the base class does *not* do this for
+  you. This lets you report the *actual* achieved value, which may differ slightly from the requested one (for
+  example if the hardware only supports coarser steps).
+- Do not implement any public setter for the front-end to call directly - the base class's `make_call()` /
+  `NumberCall` machinery handles validation and dispatches to your `control()`.
+
+### Traits
+
+The `min_value`, `max_value` and `step` bounds passed to `new_number()` end up on `this->traits` in the generated
+code, and the front-end mode (`NumberMode::NUMBER_MODE_AUTO` / `NUMBER_MODE_BOX` / `NUMBER_MODE_SLIDER`) is likewise
+set from the user's `mode:` option. If your hardware only discovers its real bounds at runtime (for example after
+probing a chip in `setup()`), you can adjust them yourself:
+
+```cpp
+void MyNumber::setup() {
+  this->traits.set_max_value(this->detected_max_());
+}
+```
+
+### Useful members
+
+- `state`: the current reported value.
+- `traits`: the `NumberTraits` object holding `min_value`/`max_value`/`step`/`mode`.
+- `publish_state(float)`: report a new value to the front-end (stores `state`, fires callbacks).
+- `LOG_NUMBER(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the number in the standard
+  format.
+
+## Exposing multiple numbers from one component
+
+Hardware often exposes more than one adjustable value - a controller hub might expose a setpoint, a deadband and a
+calibration offset, each independently tunable. There are two established ways to model this. Both are valid and
+both are widely used in-tree - which one fits depends on how the hardware itself is shaped.
+
+### A hub plus a `type` on the platform
+
+If your component already has a top-level hub - configured once to describe the device or connection - you can let
+the user add *one `number:` entry per value*, distinguished by a `type` key, using `cv.typed_schema()` with
+`key=CONF_TYPE`. Because `number.number_schema()` does not carry `min_value`, `max_value` or `step`, those bounds are
+supplied per type in `to_code`:
+
+```yaml
+controller_hub:
+  id: the_hub
+
+number:
+  - platform: controller_hub
+    type: setpoint
+    name: "Setpoint"
+  - platform: controller_hub
+    type: deadband
+    name: "Deadband"
+```
+
+```python
+from esphome.const import CONF_TYPE
+
+from .. import CONF_CONTROLLER_HUB_ID, ControllerHub, controller_hub_ns
+
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_CONTROLLER_HUB_ID): cv.use_id(ControllerHub)})
+
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "setpoint": number.number_schema(SetpointNumber).extend(_HUB_ID_SCHEMA),
+        "deadband": number.number_schema(DeadbandNumber).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+
+async def to_code(config):
+    bounds = {
+        "setpoint": (0.0, 100.0, 0.5),
+        "deadband": (0.0, 10.0, 0.1),
+    }[config[CONF_TYPE]]
+    min_value, max_value, step = bounds
+    var = await number.new_number(
+        config, min_value=min_value, max_value=max_value, step=step
+    )
+    await cg.register_parented(var, config[CONF_CONTROLLER_HUB_ID])
+```
+
+What this shape gives you:
+
+- Each value is a first-class platform entry, so it picks up the full set of per-entity options naturally.
+- Adding a new value later is purely additive - one more key in the `typed_schema` - with no reshaping of the
+  existing schema and no change to existing user configurations.
+- Different values can use different C++ classes and their own bounds.
+
+### Sub-configs on a single platform entry
+
+Many existing components instead nest optional numbers under one platform entry. Like `switch.switch_schema()`,
+`number.number_schema()` always requires a class, so this pattern still declares a dedicated class per number - it is
+just folded under one entry as an optional key. `ld2410` does this for its gate and timeout thresholds:
+
+```yaml
+number:
+  - platform: ld2410
+    ld2410_id: my_ld2410
+    timeout:
+      name: "Timeout"
+    light_threshold:
+      name: "Light Threshold"
+```
+
+On the C++ side, use the `SUB_NUMBER(name)` macro from `number.h`, which generates a protected `name##_number_`
+member (defaulted to `nullptr`) and a public `set_##name##_number()` setter:
+
+```cpp
+class LD2410Component : public PollingComponent {
+ public:
+  SUB_NUMBER(timeout)
+  SUB_NUMBER(light_threshold)
+};
+```
+
+Always null-check before use - the user may have configured only one of them.
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device
+and its values, so let the hardware decide:
+
+- **Sub-configs** fit when the values are a small, fixed set that belong to a single chip - one physical device to
+  one YAML block, which is easier to read.
+- **A hub plus `type`** fits when the values are genuinely independent things that happen to share a connection. If a
+  hub component already exists because the device or transport must be configured once and shared, then each value
+  being its own entry is the more natural fit - especially when the set is large or open-ended, or when different
+  values need different bounds or update strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses.
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component)
+for a fully worked example of both patterns.
+
+For everything else, the component implements the usual set of methods [as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/number.md
+++ b/src/content/docs/architecture/components/number.md
@@ -108,8 +108,11 @@ void MyNumber::control(float value) {
 
 A few important details:
 
-- `control()` is only called with a value that has already been validated against the configured `min_value:`,
-  `max_value:` and `step:` bounds, so you do not need to re-validate it yourself.
+- `control()` is only called with a value that has already been checked against the configured `min_value:` and
+  `max_value:`; `NumberCall` drops an out-of-range call, with a warning, before it reaches you.
+- `step:` is **not** enforced for a plain "set value" call. It is used to compute the target of the increment and
+  decrement operations, and is otherwise forwarded to the front-end as metadata - nothing snaps an incoming value onto
+  a step boundary. If your hardware needs that, round the value yourself in `control()`.
 - You should call `publish_state()` yourself once the hardware has been driven; the base class does *not* do this for
   you. This lets you report the *actual* achieved value, which may differ slightly from the requested one (for
   example if the hardware only supports coarser steps).

--- a/src/content/docs/architecture/components/output.md
+++ b/src/content/docs/architecture/components/output.md
@@ -2,4 +2,217 @@
 title: "Output"
 ---
 
+The `output` component is a hardware abstraction base, not an [entity](/architecture/components/index). It represents
+something that can be driven to a state - a GPIO pin, a PWM channel, a DAC - without being shown to the user directly.
+Outputs are *consumed* by other components: a [light](/architecture/components/light) or [fan](/architecture/components/fan)
+platform might own one to drive its hardware, and the `output.turn_on` / `output.turn_off` / `output.set_level` actions let
+users control a standalone output straight from YAML.
 
+There are two flavors:
+
+- `output::BinaryOutput`: a simple on/off output.
+- `output::FloatOutput`: a variable-level output in the range `0.0` (off) to `1.0` (fully on), such as a PWM duty cycle.
+  `FloatOutput` inherits from `BinaryOutput`, so a float output can always be used wherever a binary output is expected -
+  `1.0` and `0.0` stand in for on and off.
+
+We have two example, minimal components to start from:
+[`empty_binary_output`](https://github.com/esphome/starter-components/tree/main/components/empty_binary_output) and
+[`empty_float_output`](https://github.com/esphome/starter-components/tree/main/components/empty_float_output).
+
+## Python
+
+An output platform lives in an `output.py` file (or `output/__init__.py` package) inside your component's directory,
+allowing the user to configure it under the `output:` block:
+
+```yaml
+output:
+  - platform: my_component
+    id: my_output
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import output
+from esphome.const import CONF_ID
+
+my_output_ns = cg.esphome_ns.namespace("my_output")
+MyOutput = my_output_ns.class_("MyOutput", output.FloatOutput, cg.Component)
+```
+
+Note that `MyOutput` inherits from both `output.FloatOutput` (or `output.BinaryOutput`) and a component base
+(`cg.Component` here).
+
+### Configuration schema
+
+Unlike `sensor` or `switch`, the `output` module has no `output_schema()` / `new_output()` pair. Instead you extend the
+base schema directly - `output.BINARY_OUTPUT_SCHEMA` or `output.FLOAT_OUTPUT_SCHEMA` - which supplies the options common
+to every output (`inverted`, `power_supply`, and for float outputs `min_power` / `max_power` / `zero_means_zero`).
+Because there is no helper to declare the ID for you, you add `CONF_ID` to the schema yourself:
+
+```python
+CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
+    {
+        cv.Required(CONF_ID): cv.declare_id(MyOutput),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+```
+
+### Code generation
+
+There is no `new_output()` helper either. In `to_code`, create the variable yourself with `cg.new_Pvariable()`, then call
+`output.register_output()` to apply the common options (`inverted`, `power_supply`, `min_power`/`max_power` for float
+outputs) from the configuration:
+
+```python
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await output.register_output(var, config)
+    await cg.register_component(var, config)
+```
+
+## C++
+
+The C++ class inherits from `output::BinaryOutput` or `output::FloatOutput` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/output/float_output.h"
+
+namespace esphome::my_output {
+
+class MyOutput : public output::FloatOutput, public Component {
+ public:
+  void dump_config() override;
+
+ protected:
+  void write_state(float state) override;
+};
+
+}  // namespace esphome::my_output
+```
+
+### Writing state to hardware
+
+The one method you *must* implement is the protected virtual `write_state()`. There is no `control()`/`Call` object here
+- callers (other components, or the `output.turn_on` / `output.set_level` actions) call the public `turn_on()`,
+`turn_off()`, `set_state(bool)` or `set_level(float)` methods on the base class, which apply inversion (and, for
+`FloatOutput`, power-supply requesting plus min/max power scaling when `USE_OUTPUT_FLOAT_POWER_SCALING` is enabled)
+before calling your `write_state()` with the already-adjusted value:
+
+```cpp
+void MyOutput::write_state(float state) {
+  // `state` has already had inversion and power scaling applied - just drive the hardware.
+  this->write_pwm_duty_(state);
+}
+```
+
+For a binary output the override is `void write_state(bool state) override;` instead, and it likewise receives the
+already-inverted value.
+
+There is no `publish_state()` to call back: an output has no front-end state to report. The component that owns the
+output (a light, fan, or the `output.set_level` action) is responsible for tracking and exposing whatever state it cares
+about.
+
+### Useful members
+
+- `is_inverted()`: whether the user configured `inverted: true`.
+- `get_min_power()` / `get_max_power()`: the configured power-scaling bounds for a `FloatOutput` (`0.0`/`1.0` when power
+  scaling is not compiled in).
+- `LOG_BINARY_OUTPUT(this)` / `LOG_FLOAT_OUTPUT(this)`: convenience macros for `dump_config()` that log the inversion
+  (and, for float outputs, min/max power) state in the standard format.
+
+## Exposing multiple outputs from one component
+
+Outputs are multiple by nature: PWM drivers, I/O expanders and shift registers all drive many channels from one chip. So
+unlike the entity types, outputs are rarely modelled as sub-configs nested under a single entry. Instead the hub owns the
+chip and each channel is its own `output:` platform entry, which is what lets the user point a separate light, fan or
+`output.set_level` action at each one.
+
+### Homogeneous channels: a per-channel key
+
+When every channel behaves identically and only its index differs, give the platform a required channel key and a
+`use_id` reference back to the hub.
+[`pca9685`](https://github.com/esphome/esphome/tree/dev/esphome/components/pca9685) is the canonical example:
+
+```yaml
+pca9685:
+  frequency: 500Hz
+
+output:
+  - platform: pca9685
+    id: red_channel
+    channel: 0
+  - platform: pca9685
+    id: green_channel
+    channel: 1
+```
+
+```python
+from esphome.const import CONF_CHANNEL, CONF_ID
+
+from . import PCA9685Output, pca9685_ns
+
+DEPENDENCIES = ["pca9685"]
+
+CONF_PCA9685_ID = "pca9685_id"
+
+CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
+    {
+        cv.Required(CONF_ID): cv.declare_id(PCA9685Channel),
+        cv.GenerateID(CONF_PCA9685_ID): cv.use_id(PCA9685Output),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=15),
+    }
+)
+
+
+async def to_code(config):
+    paren = await cg.get_variable(config[CONF_PCA9685_ID])
+    var = cg.new_Pvariable(config[CONF_ID])
+    cg.add(var.set_channel(config[CONF_CHANNEL]))
+    cg.add(paren.register_channel(var))
+    await output.register_output(var, config)
+```
+
+Note that the hub is handed the channel via its own `register_channel()` method, so it knows which of its outputs to
+write when it flushes to hardware.
+
+### Heterogeneous channels: a `type` key
+
+If the channels are *not* interchangeable - some binary, some float, or backed by different registers - use
+`cv.typed_schema()` with `key=CONF_TYPE` so each variant gets its own schema, its own C++ class and the correct base
+schema. `modbus_controller`'s output platform does exactly this, distinguishing a `coil` (binary) from a `holding`
+register (float):
+
+```python
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "coil": output.BINARY_OUTPUT_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(ModbusBinaryOutput),
+                cv.Required(CONF_ADDRESS): cv.positive_int,
+            }
+        ),
+        "holding": output.FLOAT_OUTPUT_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(ModbusFloatOutput),
+                cv.Required(CONF_ADDRESS): cv.positive_int,
+            }
+        ),
+    },
+    key=CONF_TYPE,
+)
+```
+
+> [!NOTE]
+> Pick the per-channel key when the channels are interchangeable and only an index distinguishes them, and `type` when
+> they need genuinely different schemas or C++ classes. Either way, keep one `output:` entry per channel rather than
+> nesting them as sub-configs - consumers reference outputs by ID, so each one has to be independently addressable.
+
+For a comparison with how the entity types handle this, see
+[Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component).
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/output.md
+++ b/src/content/docs/architecture/components/output.md
@@ -96,8 +96,8 @@ class MyOutput : public output::FloatOutput, public Component {
 
 ### Writing state to hardware
 
-The one method you *must* implement is the protected virtual `write_state()`. There is no `control()`/`Call` object here
-- callers (other components, or the `output.turn_on` / `output.set_level` actions) call the public `turn_on()`,
+The one method you *must* implement is the protected virtual `write_state()`. There is no `control()`/`Call` object
+here - callers (other components, or the `output.turn_on` / `output.set_level` actions) call the public `turn_on()`,
 `turn_off()`, `set_state(bool)` or `set_level(float)` methods on the base class, which apply inversion (and, for
 `FloatOutput`, power-supply requesting plus min/max power scaling when `USE_OUTPUT_FLOAT_POWER_SCALING` is enabled)
 before calling your `write_state()` with the already-adjusted value:

--- a/src/content/docs/architecture/components/select.md
+++ b/src/content/docs/architecture/components/select.md
@@ -2,4 +2,232 @@
 title: "Select"
 ---
 
+The `select` component is one of ESPHome's core [entity](/architecture/components/index) types. A select offers the
+user a fixed list of string options - a mode, a preset, a channel - and lets them pick one from the front-end (Home
+Assistant, the web server, MQTT, etc.). It is conceptually similar to a [text sensor](/architecture/components/text_sensor),
+except that it can also be *written to*: in addition to reporting which option is currently active, it accepts a new
+option chosen by the user and drives some piece of hardware or internal state in response.
 
+Like the other entity types, `select` is a *platform* base. Individual components (for example a fan's preset mode,
+or an amplifier's input source) register a select and implement the logic that applies the chosen option.
+
+## Python
+
+A select platform lives in a `select.py` file (or a `select/__init__.py` package) inside your component's directory.
+This file name tells ESPHome that the component provides a `select` platform, allowing the user to configure it under
+the `select:` block:
+
+```yaml
+select:
+  - platform: my_component
+    name: "My Select"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import select
+
+my_select_ns = cg.esphome_ns.namespace("my_select")
+MySelect = my_select_ns.class_("MySelect", select.Select, cg.Component)
+```
+
+Note that `MySelect` inherits from both `select.Select` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+Use the `select.select_schema()` helper. It returns a schema pre-populated with all of the options common to every
+select - `name`, `id`, `icon`, `entity_category`, the `on_value` automation, and so on:
+
+```python
+CONFIG_SCHEMA = select.select_schema(MySelect).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MySelect`) as the first argument tells the helper which class to declare the ID for, so you do
+not need a separate `cv.GenerateID()`. Note that `select_schema()` does not itself carry the list of options - like a
+number's bounds, the option list is usually only known once you're generating code for a specific instance, so it is
+supplied to `new_select()`/`register_select()` instead.
+
+### Code generation
+
+In `to_code`, use the `select.new_select()` helper. It calls `cg.new_Pvariable()` for you *and* generates all the code
+to apply the common select options from the configuration. You must supply the list of `options` as a keyword
+argument:
+
+```python
+async def to_code(config):
+    var = await select.new_select(config, options=["Option A", "Option B", "Option C"])
+    await cg.register_component(var, config)
+```
+
+If your component owns a select as a child (rather than *being* a select), use
+`await select.register_select(var, config, options=[...])` instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `select::Select` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/select/select.h"
+
+namespace esphome::my_select {
+
+class MySelect : public select::Select, public Component {
+ public:
+  void dump_config() override;
+
+ protected:
+  void control(const std::string &value) override;
+};
+
+}  // namespace esphome::my_select
+```
+
+### Handling the new option
+
+At least one of the two `control()` overloads must be implemented: `control(size_t index)` or
+`control(const std::string &value)`. Overriding the index-based version is preferred where practical, since it avoids
+string comparisons/conversions, but overriding the string-based version is usually simplest and is what most
+components do. Whichever one you override, drive the hardware and then call `publish_state()` to acknowledge the
+option that was actually applied:
+
+```cpp
+void MySelect::control(const std::string &value) {
+  // Drive the hardware here (send a command, store a setting, etc.)
+  this->write_hardware_(value);
+
+  // Acknowledge the new option back to the front-end.
+  this->publish_state(value);
+}
+```
+
+A few important details:
+
+- `control()` is only called with a value that is already a member of the configured `options:` list, so you do not
+  need to re-validate it yourself.
+- You should call `publish_state()` yourself once the hardware has been driven; the base class does *not* do this for
+  you. `publish_state()` is overloaded for `const std::string &`, `const char *` and `size_t` (index), so you can
+  report whichever form is most convenient.
+- If you only override `control(size_t index)`, the base class's default `control(const std::string &)`
+  implementation looks up the index for you via `index_of()` and forwards to it - so most components only need to
+  implement one of the two.
+
+### Useful members
+
+- `traits`: the `SelectTraits` object holding the list of `options`, set for you via `new_select()`/`register_select()`.
+- `current_option()`: returns the currently active option as a `StringRef`, or an empty one if no state has been
+  published yet.
+- `active_index()`: returns an `optional<size_t>` with the index of the currently active option.
+- `has_option(...)` / `has_index(...)`: check whether a given option/index is valid for this select.
+- `LOG_SELECT(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the select in the standard
+  format.
+
+## Exposing multiple selects from one component
+
+Hardware often exposes more than one choice to make - a hub might expose an operating mode selector and a
+sensitivity preset selector, each with its own list of options. There are two established ways to model this. Both
+are valid and both are widely used in-tree - which one fits depends on how the hardware itself is shaped.
+
+### A hub plus a `type` on the platform
+
+If your component already has a top-level hub - configured once to describe the device or connection - you can let
+the user add *one `select:` entry per choice*, distinguished by a `type` key, using `cv.typed_schema()` with
+`key=CONF_TYPE`. Because `select.select_schema()` does not carry the option list, it is supplied per type in
+`to_code`:
+
+```yaml
+sensor_hub:
+  id: the_hub
+
+select:
+  - platform: sensor_hub
+    type: mode
+    name: "Operating Mode"
+  - platform: sensor_hub
+    type: sensitivity
+    name: "Sensitivity"
+```
+
+```python
+from esphome.const import CONF_TYPE
+
+from .. import CONF_SENSOR_HUB_ID, SensorHub, sensor_hub_ns
+
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_SENSOR_HUB_ID): cv.use_id(SensorHub)})
+
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "mode": select.select_schema(ModeSelect).extend(_HUB_ID_SCHEMA),
+        "sensitivity": select.select_schema(SensitivitySelect).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+
+async def to_code(config):
+    options = {
+        "mode": ["Auto", "Manual"],
+        "sensitivity": ["Low", "Medium", "High"],
+    }[config[CONF_TYPE]]
+    var = await select.new_select(config, options=options)
+    await cg.register_parented(var, config[CONF_SENSOR_HUB_ID])
+```
+
+What this shape gives you:
+
+- Each selector is a first-class platform entry, so it picks up the full set of per-entity options naturally.
+- Adding a new selector later is purely additive - one more key in the `typed_schema` - with no reshaping of the
+  existing schema and no change to existing user configurations.
+- Different selectors can use different C++ classes and their own option lists.
+
+### Sub-configs on a single platform entry
+
+Many existing components instead nest optional selectors under one platform entry. Like `switch.switch_schema()`,
+`select.select_schema()` always requires a class, so this pattern still declares a dedicated class per selector - it
+is just folded under one entry as an optional key. The `select` platform of `es8388` does this for its DAC output
+routing and ADC input source selectors:
+
+```yaml
+select:
+  - platform: es8388
+    es8388_id: my_es8388
+    dac_output:
+      name: "DAC Output"
+    adc_input_mic:
+      name: "ADC Input Mic"
+```
+
+On the C++ side, use the `SUB_SELECT(name)` macro from `select.h`, which generates a protected `name##_select_`
+member (defaulted to `nullptr`) and a public `set_##name##_select()` setter:
+
+```cpp
+class ES8388 : public Component {
+ public:
+  SUB_SELECT(dac_output)
+  SUB_SELECT(adc_input_mic)
+};
+```
+
+Always null-check before use - the user may have configured only one of them.
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device
+and its selectors, so let the hardware decide:
+
+- **Sub-configs** fit when the selectors are a small, fixed set that belong to a single chip - one physical device to
+  one YAML block, which is easier to read.
+- **A hub plus `type`** fits when the selectors are genuinely independent things that happen to share a connection.
+  If a hub component already exists because the device or transport must be configured once and shared, then each
+  selector being its own entry is the more natural fit - especially when the set is large or open-ended, or when
+  different selectors need different option lists or update strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses.
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component)
+for a fully worked example of both patterns.
+
+For everything else, the component implements the usual set of methods [as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/sensor.md
+++ b/src/content/docs/architecture/components/sensor.md
@@ -2,4 +2,292 @@
 title: "Sensor"
 ---
 
+The `sensor` component is one of ESPHome's core [entity](/architecture/components/index) types. A sensor represents a
+single numeric measurement - a temperature, a voltage, a humidity reading, and so on - which is published to the
+front-end (Home Assistant, the web server, MQTT, etc.) as a floating point value.
 
+Rather than being used on its own, `sensor` is a *platform* base: individual components (for example `dht`, `adc` or
+`bmp280`) register one or more sensors and periodically push new values into them. If you are writing a component that
+measures something, you will almost always expose that measurement as a sensor.
+
+We have an [example, minimal sensor component](https://github.com/esphome/starter-components/tree/main/components/empty_sensor)
+which is a good starting point.
+
+## Python
+
+A sensor platform lives in a `sensor.py` file (or a `sensor/__init__.py` package) inside your component's directory. This
+file name tells ESPHome that the component provides a `sensor` platform, allowing the user to configure it under the
+`sensor:` block:
+
+```yaml
+sensor:
+  - platform: my_component
+    name: "My Measurement"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import UNIT_CELSIUS, ICON_THERMOMETER, DEVICE_CLASS_TEMPERATURE
+
+my_sensor_ns = cg.esphome_ns.namespace("my_sensor")
+MySensor = my_sensor_ns.class_("MySensor", cg.PollingComponent, sensor.Sensor)
+```
+
+Note that `MySensor` inherits from both a component base (`cg.PollingComponent` here, since a sensor is usually polled)
+and `sensor.Sensor`.
+
+### Configuration schema
+
+Instead of building the schema from scratch, use the `sensor.sensor_schema()` helper. It returns a schema pre-populated
+with all of the options common to every sensor - `name`, `id`, `filters`, `accuracy_decimals`, `unit_of_measurement`,
+`device_class`, `state_class`, `entity_category` and so on - and lets you supply sensible defaults for your specific
+device:
+
+```python
+CONFIG_SCHEMA = sensor.sensor_schema(
+    MySensor,
+    unit_of_measurement=UNIT_CELSIUS,
+    icon=ICON_THERMOMETER,
+    accuracy_decimals=1,
+    device_class=DEVICE_CLASS_TEMPERATURE,
+    state_class=sensor.StateClass.MEASUREMENT,
+).extend(cv.polling_component_schema("60s"))
+```
+
+Passing your class (`MySensor`) as the first argument tells the helper which class to declare the ID for, so you do not
+need a separate `cv.GenerateID()`. The `.extend(cv.polling_component_schema("60s"))` call adds the `update_interval`
+option with a default of 60 seconds.
+
+### Code generation
+
+In `to_code`, use the `sensor.new_sensor()` helper. It calls `cg.new_Pvariable()` for you *and* generates all the code
+to apply the common sensor options (name, unit, filters, etc.) from the configuration:
+
+```python
+async def to_code(config):
+    var = await sensor.new_sensor(config)
+    await cg.register_component(var, config)
+```
+
+If your component owns a sensor as a child (rather than *being* a sensor), use `await sensor.register_sensor(var, config)`
+instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `sensor::Sensor` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+
+namespace esphome::my_sensor {
+
+class MySensor : public sensor::Sensor, public PollingComponent {
+ public:
+  void update() override;
+  void dump_config() override;
+};
+
+}  // namespace esphome::my_sensor
+```
+
+### Publishing values
+
+`sensor::Sensor` is a read-only entity: there is no command coming back from the front-end. Your only job is to push
+new measurements out. Whenever you have a new reading, call `publish_state()`:
+
+```cpp
+void MySensor::update() {
+  float value = this->read_measurement_();
+  this->publish_state(value);
+}
+```
+
+`publish_state()` takes the raw `float` value, passes it through the user-configured [filter chain](https://esphome.io/components/sensor/#sensor-filters)
+(offsets, moving averages, calibration, etc.), stores the final result in the `state` member and notifies all
+front-ends. Publish the raw, unfiltered value - the filters the user configured in YAML are applied for you.
+
+To publish an "unknown"/unavailable state, publish `NAN` (`quiet_NaN`).
+
+### Useful members
+
+- `state`: the most recent published (filtered) value.
+- `has_state()`: whether a value has ever been published.
+- `get_accuracy_decimals()` / `get_unit_of_measurement()` / `get_device_class()`: the metadata configured by the user or
+  by your schema defaults.
+- `LOG_SENSOR(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the sensor's name, unit, accuracy
+  and device class in the standard format.
+
+## Exposing multiple sensors from one component
+
+Hardware rarely maps to exactly one sensor. A DHT22 reports temperature *and* humidity; a power meter reports voltage,
+current and power; a BLE device may expose a dozen readings. There are two established ways to model this. Both are
+valid and both are widely used in-tree - which one fits depends on how the hardware itself is shaped, so read the two
+together and pick the one that describes your device more honestly.
+
+### A hub plus a `type` on the platform
+
+If your component already has a top-level hub component - something the user configures once to describe the device or
+connection - you can let the user add *one `sensor:` entry per reading*, distinguished by a `type` key. Use
+`cv.typed_schema()` with `key=CONF_TYPE`:
+
+```yaml
+# The hub: configured once.
+my_hub:
+  id: the_hub
+
+sensor:
+  - platform: my_hub
+    type: voltage
+    name: "Voltage"
+  - platform: my_hub
+    type: current
+    name: "Current"
+    filters:
+      - throttle: 10s
+```
+
+Each `type` gets its own schema, so each can declare its own unit, accuracy, device class and even its own C++ class
+and component base:
+
+```python
+from esphome.const import CONF_TYPE
+
+from .. import CONF_MY_HUB_ID, MyHub, my_hub_ns
+
+DEPENDENCIES = ["my_hub"]
+
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_MY_HUB_ID): cv.use_id(MyHub)})
+
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "voltage": sensor.sensor_schema(
+            MyHubVoltageSensor,
+            unit_of_measurement=UNIT_VOLT,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_VOLTAGE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(_HUB_ID_SCHEMA),
+        "current": sensor.sensor_schema(
+            MyHubCurrentSensor,
+            unit_of_measurement=UNIT_AMPERE,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_CURRENT,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+
+async def to_code(config):
+    var = await sensor.new_sensor(config)
+    await cg.register_component(var, config)
+    await cg.register_parented(var, config[CONF_MY_HUB_ID])
+```
+
+`cg.register_parented()` gives each sensor a `parent_` pointer back to the hub, so the hub can push readings into it (or
+the sensor can pull from the hub). See the `sensor` platform of the `sendspin` component for a real, in-tree example of
+this pattern.
+
+What this shape gives you:
+
+- Each sensor is a first-class platform entry, so it picks up the full set of per-entity options naturally.
+- Adding a new reading later is purely additive - one more key in the `typed_schema` - with no reshaping of the existing
+  schema and no change to existing user configurations.
+- Different readings can use different C++ classes and component bases (for example one polled at an interval, another
+  updated only when an event arrives).
+
+### Sub-configs on a single platform entry
+
+Many existing components instead expose all of their readings as optional *sub-configs* nested under one platform entry.
+[`dht`](https://github.com/esphome/esphome/tree/dev/esphome/components/dht) is the simplest example:
+
+```yaml
+sensor:
+  - platform: dht
+    pin: GPIO22
+    temperature:
+      name: "Living Room Temperature"
+    humidity:
+      name: "Living Room Humidity"
+```
+
+Here the *component* is the platform entry, and each reading is an optional key whose value is an inline
+`sensor.sensor_schema()`. Note that `sensor_schema()` is called without a class argument, so each sub-config declares a
+plain `sensor::Sensor`:
+
+```python
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(DHT),
+        cv.Required(CONF_PIN): pins.internal_gpio_input_pullup_pin_schema,
+        cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(...),
+    }
+).extend(cv.polling_component_schema("60s"))
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    if temperature_config := config.get(CONF_TEMPERATURE):
+        sens = await sensor.new_sensor(temperature_config)
+        cg.add(var.set_temperature_sensor(sens))
+```
+
+On the C++ side, your component holds a pointer per reading and publishes to whichever ones the user configured. Rather
+than writing those members and setters out by hand, use the `SUB_SENSOR(name)` macro from `sensor.h`, which generates a
+protected `name##_sensor_` member (defaulted to `nullptr`) and a public `set_##name##_sensor()` setter:
+
+```cpp
+class MyComponent final : public PollingComponent {
+ public:
+  SUB_SENSOR(temperature)
+  SUB_SENSOR(humidity)
+
+  void update() override;
+};
+
+void MyComponent::update() {
+  // Always null-check: the user may have configured only one of them.
+  if (this->temperature_sensor_ != nullptr) {
+    this->temperature_sensor_->publish_state(this->read_temperature_());
+  }
+  if (this->humidity_sensor_ != nullptr) {
+    this->humidity_sensor_->publish_state(this->read_humidity_());
+  }
+}
+```
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device and
+its readings, so let the hardware decide:
+
+- **Sub-configs** fit when the readings are facets of one inseparable measurement cycle. `dht` reads temperature and
+  humidity from a single bus transaction, so a single entry with two optional sub-keys mirrors what the chip actually
+  does. This also keeps one physical device to one YAML block, which is easier to read.
+- **A hub plus `type`** fits when the readings are genuinely independent things that happen to share a connection. If a
+  hub component already exists because the device or transport must be configured once and shared, then each reading
+  being its own entry is the more natural fit - especially when the set is large or open-ended, or when different
+  readings need different C++ classes, polling intervals or update strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses. In a
+new component with no hub, sub-configs are usually the smaller change.
+
+Equivalent `SUB_*` macros exist for the other entity types that are commonly exposed this way:
+`SUB_BINARY_SENSOR`, `SUB_BUTTON`, `SUB_NUMBER`, `SUB_SELECT`, `SUB_SWITCH` and `SUB_TEXT_SENSOR`.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/speaker.md
+++ b/src/content/docs/architecture/components/speaker.md
@@ -2,4 +2,121 @@
 title: "Speaker"
 ---
 
+The `speaker` component is a hardware abstraction base, not an [entity](/architecture/components/index). A speaker is an
+audio *sink*: something you can push a stream of PCM audio bytes into. It is not shown to the user in the front-end
+directly - instead it is consumed by higher-level audio components such as `media_player` or a voice assistant, which
+feed it decoded audio data and drive its `on`/`off`/`playing` lifecycle. If you are writing a component that turns audio
+data into sound on some piece of hardware (an I2S DAC, a Bluetooth link, etc.), you expose it as a speaker.
 
+There is no starter component for `speaker` in the [starter-components](https://github.com/esphome/starter-components)
+repository, so this page walks through the base class and platform module directly instead.
+
+## Python
+
+A speaker platform lives in a `speaker.py` file (or `speaker/__init__.py` package) inside your component's directory,
+allowing the user to configure it under the `speaker:` block:
+
+```yaml
+speaker:
+  - platform: my_component
+    id: my_speaker
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import speaker
+from esphome.const import CONF_ID
+
+my_speaker_ns = cg.esphome_ns.namespace("my_speaker")
+MySpeaker = my_speaker_ns.class_("MySpeaker", speaker.Speaker, cg.Component)
+```
+
+Note that `MySpeaker` inherits from both `speaker.Speaker` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+As with `output`, there is no `speaker_schema()` / `new_speaker()` pair. `esphome.components.speaker` provides
+`SPEAKER_SCHEMA`, built on top of `audio.AUDIO_COMPONENT_SCHEMA` (the common `bits_per_sample`, `num_channels` and
+`sample_rate` options shared by audio components) plus an optional `audio_dac` for volume/mute control. Extend it and
+add your own `CONF_ID`, since - again - there is no helper to declare it for you:
+
+```python
+CONFIG_SCHEMA = speaker.SPEAKER_SCHEMA.extend(
+    {
+        cv.Required(CONF_ID): cv.declare_id(MySpeaker),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+```
+
+### Code generation
+
+Create the variable yourself with `cg.new_Pvariable()`, then call `speaker.register_speaker()` to wire up the options
+that `SPEAKER_SCHEMA` understands (currently just `audio_dac`, if configured):
+
+```python
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await speaker.register_speaker(var, config)
+    await cg.register_component(var, config)
+```
+
+## C++
+
+The C++ class inherits from `speaker::Speaker` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/speaker/speaker.h"
+
+namespace esphome::my_speaker {
+
+class MySpeaker : public speaker::Speaker, public Component {
+ public:
+  void start() override;
+  void stop() override;
+  bool has_buffered_data() const override;
+
+  size_t play(const uint8_t *data, size_t length) override;
+};
+
+}  // namespace esphome::my_speaker
+```
+
+### Consuming audio data
+
+`speaker::Speaker` has no `control()`/`Call` object and no `publish_state()` - it is a pure data sink, driven directly
+by whichever component holds a pointer to it. The methods you implement are:
+
+- `play(const uint8_t *data, size_t length)`: the core method. Write (or buffer) as much of `data` as you can and return
+  the number of bytes actually consumed - callers are expected to retry with the remainder if you return less than
+  `length`. A `play(const std::vector<uint8_t> &)` convenience overload is provided by the base class for you.
+- `start()` / `stop()`: begin or immediately halt playback. `finish()` is an optional third option - "play out the
+  buffer, then stop" - which defaults to calling `stop()` if you do not override it.
+- `has_buffered_data()`: whether there is still audio queued up that has not finished playing.
+
+```cpp
+size_t MySpeaker::play(const uint8_t *data, size_t length) {
+  size_t written = this->write_to_dma_buffer_(data, length);
+  return written;
+}
+```
+
+Before sending data, callers configure the stream format via `set_audio_stream_info()` (an `audio::AudioStreamInfo`
+describing sample rate, bit depth and channel count); read it back with `get_audio_stream_info()` if your hardware needs
+to be reconfigured to match.
+
+### Useful members
+
+- `is_running()` / `is_stopped()`: convenience checks against the internal `state_` (`STATE_STOPPED`, `STATE_STARTING`,
+  `STATE_RUNNING`, `STATE_STOPPING`). Your implementation is responsible for updating `state_` as playback progresses.
+- `set_volume(float)` / `get_volume()` and `set_mute_state(bool)` / `get_mute_state()`: forward to a configured
+  `audio_dac` component when one is set via `set_audio_dac()`; override them if your hardware needs to handle volume or
+  mute in software instead.
+- `add_audio_output_callback(F &&callback)`: register a callback invoked with `(frames_played, timestamp_us)` so other
+  components can track playback progress against wall-clock time.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/switch.md
+++ b/src/content/docs/architecture/components/switch.md
@@ -2,4 +2,232 @@
 title: "Switch"
 ---
 
+The `switch` component is one of ESPHome's core [entity](/architecture/components/index) types. A switch is a simple
+two-state (ON/OFF) entity that the user can control from the front-end (Home Assistant, the web server, MQTT, etc.). It
+is conceptually a [binary sensor](/architecture/components/binary_sensor) that can also be *written to*: in addition to
+reporting its current state, it accepts turn-on/turn-off/toggle commands and drives some piece of hardware in response.
 
+Like the other entity types, `switch` is a *platform* base. Individual components (for example `gpio`, `template` or a
+relay board) register a switch and implement the logic that actually turns the hardware on and off.
+
+We have an [example, minimal switch component](https://github.com/esphome/starter-components/tree/main/components/empty_switch)
+which is a good starting point.
+
+## Python
+
+A switch platform lives in a `switch.py` file (or a `switch/__init__.py` package) inside your component's directory. This
+file name tells ESPHome that the component provides a `switch` platform, allowing the user to configure it under the
+`switch:` block:
+
+```yaml
+switch:
+  - platform: my_component
+    name: "My Switch"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import switch
+
+my_switch_ns = cg.esphome_ns.namespace("my_switch")
+MySwitch = my_switch_ns.class_("MySwitch", switch.Switch, cg.Component)
+```
+
+Note that `MySwitch` inherits from both `switch.Switch` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+Use the `switch.switch_schema()` helper. It returns a schema pre-populated with all of the options common to every
+switch - `name`, `id`, `icon`, `inverted`, `restore_mode`, `device_class`, `entity_category`, the `on_turn_on` /
+`on_turn_off` automations, and so on - and lets you pass defaults for your device:
+
+```python
+CONFIG_SCHEMA = switch.switch_schema(MySwitch).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MySwitch`) as the first argument tells the helper which class to declare the ID for, so you do not
+need a separate `cv.GenerateID()`.
+
+### Code generation
+
+In `to_code`, use the `switch.new_switch()` helper. It calls `cg.new_Pvariable()` for you *and* generates all the code to
+apply the common switch options from the configuration:
+
+```python
+async def to_code(config):
+    var = await switch.new_switch(config)
+    await cg.register_component(var, config)
+```
+
+If your component owns a switch as a child (rather than *being* a switch), use `await switch.register_switch(var, config)`
+instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `switch_::Switch` alongside its component base. Note the trailing underscore in the
+namespace: `switch` is a reserved C++ keyword, so the namespace is spelled `switch_`.
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/switch/switch.h"
+
+namespace esphome::my_switch {
+
+class MySwitch : public switch_::Switch, public Component {
+ public:
+  void dump_config() override;
+
+ protected:
+  void write_state(bool state) override;
+};
+
+}  // namespace esphome::my_switch
+```
+
+### Writing state to hardware
+
+The one method you *must* implement is `write_state()`. It is called by the front-end when the user (or an automation)
+turns the switch on or off. Your implementation drives the hardware and then calls `publish_state()` to acknowledge that
+the new state was applied:
+
+```cpp
+void MySwitch::write_state(bool state) {
+  // Drive the hardware here (set a GPIO, send a command, etc.)
+  this->write_hardware_(state);
+
+  // Acknowledge the new state back to the front-end.
+  this->publish_state(state);
+}
+```
+
+A few important details:
+
+- The `state` argument already has the user's `inverted:` option applied, so you can write it to the hardware directly.
+- You should call `publish_state()` yourself once the hardware has been driven; the base class does *not* do this for
+  you. This lets you report the *actual* achieved state, which may differ from the requested one.
+- Do not implement `turn_on()` / `turn_off()` / `toggle()` - those are provided by the base class and ultimately call
+  your `write_state()`.
+
+### Assumed state and restore mode
+
+- If your switch cannot read back the real hardware state (so the reported state is only what ESPHome last wrote),
+  override `assumed_state()` to return `true`. The front-end will then show separate ON and OFF buttons rather than a
+  single toggle.
+- The base class handles the user's `restore_mode:` option (restoring the previous state from flash on boot). At the end
+  of `setup()`, you can consult `get_initial_state_with_restore_mode()` to decide what state to apply.
+
+### Useful members
+
+- `state`: the current reported state.
+- `publish_state(bool)`: report a new state to the front-end (applies inversion, stores `state`, fires callbacks).
+- `LOG_SWITCH(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the switch in the standard format.
+
+## Exposing multiple switches from one component
+
+Hardware often maps to more than one switch - a relay board might drive four independent relays, or a device hub
+might expose several unrelated feature toggles (a buzzer, a night light, a child lock). There are two established
+ways to model this. Both are valid and both are widely used in-tree - which one fits depends on how the hardware
+itself is shaped.
+
+### A hub plus a `type` on the platform
+
+If your component already has a top-level hub - configured once to describe the device or connection - you can let
+the user add *one `switch:` entry per relay*, distinguished by a `type` key, using `cv.typed_schema()` with
+`key=CONF_TYPE`:
+
+```yaml
+relay_hub:
+  id: the_hub
+
+switch:
+  - platform: relay_hub
+    type: relay_1
+    name: "Relay 1"
+  - platform: relay_hub
+    type: relay_2
+    name: "Relay 2"
+```
+
+```python
+from esphome.const import CONF_TYPE
+
+from .. import CONF_RELAY_HUB_ID, RelayHub, relay_hub_ns
+
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_RELAY_HUB_ID): cv.use_id(RelayHub)})
+
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "relay_1": switch.switch_schema(Relay1Switch).extend(_HUB_ID_SCHEMA),
+        "relay_2": switch.switch_schema(Relay2Switch).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+
+async def to_code(config):
+    var = await switch.new_switch(config)
+    await cg.register_parented(var, config[CONF_RELAY_HUB_ID])
+```
+
+What this shape gives you:
+
+- Each relay is a first-class platform entry, so it picks up the full set of per-entity options naturally.
+- Adding a new relay later is purely additive - one more key in the `typed_schema` - with no reshaping of the
+  existing schema and no change to existing user configurations.
+- Different relays can use different C++ classes.
+
+The `switch` platform of `dfrobot_sen0395` is a real in-tree example - its `type:` selects which of four switches
+(power, LED, UART presence, start-after-boot) a given entry controls.
+
+### Sub-configs on a single platform entry
+
+Many existing components instead nest optional switches under one platform entry. Unlike `sensor.sensor_schema()`,
+`switch.switch_schema()` always requires a class, so this pattern still declares a dedicated class per switch - it is
+just folded under one entry as an optional key instead of getting its own `type:`. `ld2410` does this for its
+`engineering_mode` and `bluetooth` switches:
+
+```yaml
+switch:
+  - platform: ld2410
+    ld2410_id: my_ld2410
+    engineering_mode:
+      name: "Engineering Mode"
+    bluetooth:
+      name: "Bluetooth"
+```
+
+On the C++ side, use the `SUB_SWITCH(name)` macro from `switch.h`, which generates a protected `name##_switch_`
+member (defaulted to `nullptr`) and a public `set_##name##_switch()` setter:
+
+```cpp
+class LD2410Component : public PollingComponent {
+ public:
+  SUB_SWITCH(engineering_mode)
+  SUB_SWITCH(bluetooth)
+};
+```
+
+Always null-check before use - the user may have configured only one of them.
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device
+and its switches, so let the hardware decide:
+
+- **Sub-configs** fit when the switches are a small, fixed set that belong to a single chip - one physical device to
+  one YAML block, which is easier to read.
+- **A hub plus `type`** fits when the switches are genuinely independent things that happen to share a connection.
+  If a hub component already exists because the device or transport must be configured once and shared, then each
+  switch being its own entry is the more natural fit - especially when the set is large or open-ended, or when
+  different switches need different C++ classes or update strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses.
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component)
+for a fully worked example of both patterns.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/text.md
+++ b/src/content/docs/architecture/components/text.md
@@ -107,8 +107,10 @@ void MyText::control(const std::string &value) {
 
 A few important details:
 
-- `control()` is only called with a value that has already been validated against the configured `min_length:`,
-  `max_length:` and `pattern:` (if any), so you do not need to re-validate it yourself.
+- `control()` is only called with a value that has already been checked against the configured `min_length:` and
+  `max_length:`; `TextCall` drops a call violating either, with a warning, before it reaches you.
+- `pattern:` is **not** enforced on-device. It is forwarded to the front-end as metadata for client-side validation
+  only, so nothing validates it before `control()` runs. If your hardware depends on the format, check it yourself.
 - You should call `publish_state()` yourself once the hardware has been driven; the base class does *not* do this for
   you. This lets you report the *actual* stored value, which may differ from the requested one.
 - If the entity's `mode:` is `PASSWORD`, `publish_state()` automatically redacts the value in the logs (via

--- a/src/content/docs/architecture/components/text.md
+++ b/src/content/docs/architecture/components/text.md
@@ -2,4 +2,202 @@
 title: "Text"
 ---
 
+The `text` component is one of ESPHome's core [entity](/architecture/components/index) types. A text entity holds a
+single user-editable string - a hostname, an API key, a free-form label - that the user can set from the front-end
+(Home Assistant, the web server, MQTT, etc.). Do not confuse it with [text sensor](/architecture/components/text_sensor):
+a text sensor only *reports* a string chosen by the component, while a `text` entity can also be *written to* by the
+user, and the component drives some piece of hardware or internal state in response.
 
+Like the other entity types, `text` is a *platform* base. Individual components (for example a device that stores a
+configurable label or credential) register a text entity and implement the logic that applies the new string.
+
+## Python
+
+A text platform lives in a `text.py` file (or a `text/__init__.py` package) inside your component's directory. This
+file name tells ESPHome that the component provides a `text` platform, allowing the user to configure it under the
+`text:` block:
+
+```yaml
+text:
+  - platform: my_component
+    name: "My Text"
+    mode: text
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text
+
+my_text_ns = cg.esphome_ns.namespace("my_text")
+MyText = my_text_ns.class_("MyText", text.Text, cg.Component)
+```
+
+Note that `MyText` inherits from both `text.Text` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+Use the `text.text_schema()` helper. It returns a schema pre-populated with all of the options common to every text
+entity - `name`, `id`, `icon`, `entity_category`, `mode`, the `on_value` automation, and so on:
+
+```python
+CONFIG_SCHEMA = text.text_schema(MyText, mode="TEXT").extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyText`) as the first argument tells the helper which class to declare the ID for, so you do not
+need a separate `cv.GenerateID()`. Unlike `switch_schema()`, the base schema requires `mode:` to be present in the
+configuration; passing `mode=` to `text_schema()` (as above) supplies a default so the user does not have to specify
+it themselves. `min_length`, `max_length` and `pattern` are *not* part of the schema at all - like a number's bounds,
+they are supplied later, in `to_code`.
+
+### Code generation
+
+In `to_code`, use the `text.new_text()` helper. It calls `cg.new_Pvariable()` for you *and* generates all the code to
+apply the common text options from the configuration. `min_length`, `max_length` and `pattern` are optional keyword
+arguments (defaulting to `0`, `255` and no pattern):
+
+```python
+async def to_code(config):
+    var = await text.new_text(config, min_length=0, max_length=32)
+    await cg.register_component(var, config)
+```
+
+If your component owns a text entity as a child (rather than *being* one), use
+`await text.register_text(var, config, min_length=..., max_length=..., pattern=...)` instead, having declared the ID
+yourself.
+
+## C++
+
+The C++ class inherits from `text::Text` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/text/text.h"
+
+namespace esphome::my_text {
+
+class MyText : public text::Text, public Component {
+ public:
+  void dump_config() override;
+
+ protected:
+  void control(const std::string &value) override;
+};
+
+}  // namespace esphome::my_text
+```
+
+### Handling the new value
+
+The one method you *must* implement is `control()`. It is called by the front-end when the user (or an automation)
+sets a new string. Your implementation drives the hardware and then calls `publish_state()` to acknowledge the value
+that was actually applied:
+
+```cpp
+void MyText::control(const std::string &value) {
+  // Drive the hardware here (store a setting, send a command, etc.)
+  this->write_hardware_(value);
+
+  // Acknowledge the new value back to the front-end.
+  this->publish_state(value);
+}
+```
+
+A few important details:
+
+- `control()` is only called with a value that has already been validated against the configured `min_length:`,
+  `max_length:` and `pattern:` (if any), so you do not need to re-validate it yourself.
+- You should call `publish_state()` yourself once the hardware has been driven; the base class does *not* do this for
+  you. This lets you report the *actual* stored value, which may differ from the requested one.
+- If the entity's `mode:` is `PASSWORD`, `publish_state()` automatically redacts the value in the logs (via
+  `LOG_SECRET`) - you do not need to handle that yourself.
+
+### Useful members
+
+- `state`: the current reported string.
+- `traits`: the `TextTraits` object holding `min_length`/`max_length`/`pattern`/`mode` (`TextMode::TEXT_MODE_TEXT` or
+  `TEXT_MODE_PASSWORD`).
+- `publish_state(const std::string &)`: report a new value to the front-end (stores `state`, fires callbacks).
+- `LOG_TEXT(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the text entity in the standard
+  format.
+
+## Exposing multiple texts from one component
+
+Hardware often exposes more than one free-form string - a network sign controller, for example, might let you set
+both its Wi-Fi SSID and a scrolling banner message. As with sensors, there are two established ways to model this.
+Both are valid and both are widely used in-tree - which one fits depends on how the hardware itself is shaped.
+
+### A hub plus a `type` on the platform
+
+If your component already has a top-level hub, let the user add one `text:` entry per field, distinguished by a
+`type` key via `cv.typed_schema()`:
+
+```yaml
+text:
+  - platform: my_hub
+    type: ssid
+    name: "SSID"
+  - platform: my_hub
+    type: banner
+    name: "Banner Message"
+```
+
+```python
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "ssid": text.text_schema(MyHubSSIDText, mode="TEXT").extend(_HUB_ID_SCHEMA),
+        "banner": text.text_schema(MyHubBannerText, mode="TEXT").extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+
+async def to_code(config):
+    var = await text.new_text(config)
+    await cg.register_parented(var, config[CONF_MY_HUB_ID])
+```
+
+What this shape gives you:
+
+- Each field is a first-class platform entry, so it picks up the full set of per-entity options naturally.
+- Adding a new field later is purely additive - one more key in the `typed_schema` - with no reshaping of the
+  existing schema and no change to existing user configurations.
+
+### Sub-configs on a single platform entry
+
+Some components instead nest optional fields under one platform entry, each an inline
+`cv.Optional(CONF_SSID): text.text_schema(mode="TEXT")` - note `text_schema()` called *without* a class argument.
+There is no `SUB_TEXT` macro (`SUB_*` exists only for `binary_sensor`, `button`, `number`, `select`, `sensor`,
+`switch` and `text_sensor`), so declare the pointer member and setter by hand, and null-check before publishing since
+the user may configure only one field:
+
+```cpp
+class MyComponent final : public Component {
+ public:
+  void set_ssid_text(text::Text *ssid_text) { this->ssid_text_ = ssid_text; }
+
+ protected:
+  text::Text *ssid_text_{nullptr};
+};
+```
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component)
+for a fully worked example of both patterns, including the matching Python schema and `to_code`.
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device
+and its fields, so let the hardware decide:
+
+- **Sub-configs** fit when the fields are a small, fixed set that belong to a single device - one physical device to
+  one YAML block, which is easier to read.
+- **A hub plus `type`** fits when the fields are genuinely independent things that happen to share a connection. If a
+  hub component already exists because the device or transport must be configured once and shared, then each field
+  being its own entry is the more natural fit - especially when the set is large or open-ended, or when different
+  fields need different update strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses.
+
+For everything else, the component implements the usual set of methods [as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/text_sensor.md
+++ b/src/content/docs/architecture/components/text_sensor.md
@@ -2,4 +2,193 @@
 title: "Text Sensor"
 ---
 
+The `text_sensor` component is one of ESPHome's core [entity](/architecture/components/index) types. A text sensor
+represents a single string-valued measurement - a firmware version, an IP address, the currently playing track, and
+so on - which is published to the front-end (Home Assistant, the web server, MQTT, etc.) as a string value. It is the
+string-valued analogue of [sensor](/architecture/components/sensor): where `sensor` publishes a `float`, `text_sensor`
+publishes an `std::string`.
 
+Rather than being used on its own, `text_sensor` is a *platform* base: individual components (for example `version`,
+`wifi_info` or `mqtt_subscribe`) register one or more text sensors and periodically push new values into them. If you
+are writing a component that produces a textual reading, you will almost always expose that reading as a text sensor.
+
+We have an [example, minimal text sensor component](https://github.com/esphome/starter-components/tree/main/components/empty_text_sensor)
+which is a good starting point.
+
+## Python
+
+A text sensor platform lives in a `text_sensor.py` file (or a `text_sensor/__init__.py` package) inside your
+component's directory. This file name tells ESPHome that the component provides a `text_sensor` platform, allowing
+the user to configure it under the `text_sensor:` block:
+
+```yaml
+text_sensor:
+  - platform: my_component
+    name: "My Text Value"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor
+
+my_text_sensor_ns = cg.esphome_ns.namespace("my_text_sensor")
+MyTextSensor = my_text_sensor_ns.class_("MyTextSensor", text_sensor.TextSensor, cg.Component)
+```
+
+Note that `MyTextSensor` inherits from both `text_sensor.TextSensor` and a component base (`cg.Component` here, or
+`cg.PollingComponent` if you need to poll for a new value).
+
+### Configuration schema
+
+Use the `text_sensor.text_sensor_schema()` helper. It returns a schema pre-populated with all of the options common
+to every text sensor - `name`, `id`, `icon`, `device_class`, `entity_category`, `filters` and so on - and lets you
+pass defaults for your specific device:
+
+```python
+CONFIG_SCHEMA = text_sensor.text_sensor_schema(MyTextSensor).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyTextSensor`) as the first argument tells the helper which class to declare the ID for, so you
+do not need a separate `cv.GenerateID()`.
+
+### Code generation
+
+In `to_code`, use the `text_sensor.new_text_sensor()` helper. It calls `cg.new_Pvariable()` for you *and* generates
+all the code to apply the common text sensor options (name, filters, etc.) from the configuration:
+
+```python
+async def to_code(config):
+    var = await text_sensor.new_text_sensor(config)
+    await cg.register_component(var, config)
+```
+
+If your component owns a text sensor as a child (rather than *being* a text sensor), use
+`await text_sensor.register_text_sensor(var, config)` instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `text_sensor::TextSensor` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+
+namespace esphome::my_text_sensor {
+
+class MyTextSensor : public text_sensor::TextSensor, public PollingComponent {
+ public:
+  void update() override;
+  void dump_config() override;
+};
+
+}  // namespace esphome::my_text_sensor
+```
+
+### Publishing values
+
+`text_sensor::TextSensor` is a read-only entity: there is no command coming back from the front-end. Your only job is
+to push new values out. Whenever you have a new reading, call `publish_state()`:
+
+```cpp
+void MyTextSensor::update() {
+  std::string value = this->read_value_();
+  this->publish_state(value);
+}
+```
+
+`publish_state()` accepts an `std::string`, a `const char *`, or a `const char *` plus length. It passes the value
+through the user-configured [filter chain](https://esphome.io/components/text_sensor/#text-sensor-filters)
+(uppercasing, substitution, mapping, etc.), stores the final result in the `state` member and notifies all
+front-ends. Publish the raw, unfiltered value - the filters the user configured in YAML are applied for you.
+
+### Useful members
+
+- `state`: the most recent published (filtered) value.
+- `get_state()`: getter-syntax accessor for `state`.
+- `get_raw_state()`: the pre-filter value, when a filter chain is configured.
+- `LOG_TEXT_SENSOR(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the text sensor's name in
+  the standard format.
+
+## Exposing multiple text sensors from one component
+
+Hardware often maps to more than one text sensor - a device hub might expose a firmware version, a serial number and
+a current-status string, all read from the same connection. There are two established ways to model this. Both are
+valid and both are widely used in-tree - which one fits depends on how the hardware itself is shaped, so read the two
+together and pick the one that describes your device more honestly.
+
+### A hub plus a `type` on the platform
+
+If your component already has a top-level hub, let the user add *one `text_sensor:` entry per string*, distinguished
+by a `type` key, using `cv.typed_schema()` with `key=CONF_TYPE`:
+
+```yaml
+text_sensor:
+  - platform: my_hub
+    type: firmware_version
+    name: "Firmware Version"
+  - platform: my_hub
+    type: serial_number
+    name: "Serial Number"
+```
+
+```python
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_MY_HUB_ID): cv.use_id(MyHub)})
+
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "firmware_version": text_sensor.text_sensor_schema(MyHubFirmwareVersionTextSensor).extend(_HUB_ID_SCHEMA),
+        "serial_number": text_sensor.text_sensor_schema(MyHubSerialNumberTextSensor).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+async def to_code(config):
+    var = await text_sensor.new_text_sensor(config)
+    await cg.register_parented(var, config[CONF_MY_HUB_ID])
+```
+
+Each entry is a first-class platform entry with the full set of per-entity options, adding a new string later is
+purely additive, and different strings could use different C++ classes.
+
+### Sub-configs on a single platform entry
+
+Many components instead nest optional sub-keys under one platform entry, each an inline
+`text_sensor.text_sensor_schema()` called without a class argument - [`pylontech`](https://github.com/esphome/esphome/tree/dev/esphome/components/pylontech)
+does exactly this for its `base_state`, `voltage_state`, `current_state` and `temperature_state` strings, all read
+from the same battery. Use `SUB_TEXT_SENSOR(name)` from `text_sensor.h`, which generates a protected
+`name##_text_sensor_` member (defaulted to `nullptr`) and a public `set_##name##_text_sensor()` setter. Always
+null-check before publishing, since the user may have configured only some of them:
+
+```cpp
+class MyComponent final : public Component {
+ public:
+  SUB_TEXT_SENSOR(firmware_version)
+  SUB_TEXT_SENSOR(serial_number)
+};
+// this->firmware_version_text_sensor_->publish_state(version); once null-checked
+```
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component)
+for a fully worked example of both patterns.
+
+### Choosing between them
+
+Neither pattern is the "modern" one and neither is deprecated. They express different relationships between a device
+and its strings, so let the hardware decide:
+
+- **Sub-configs** fit when the strings are facets of one inseparable read cycle. `pylontech` reads `base_state`,
+  `voltage_state`, `current_state` and `temperature_state` from a single battery poll, so one entry with several
+  optional sub-keys mirrors what the device actually reports. This also keeps one physical device to one YAML block,
+  which is easier to read.
+- **A hub plus `type`** fits when the strings are genuinely independent things that happen to share a connection. If
+  a hub component already exists because the device or transport must be configured once and shared, then each
+  string being its own entry is the more natural fit - especially when the set is large or open-ended, or when
+  different strings need different C++ classes or update strategies.
+
+If both descriptions fit your device equally well, follow whichever pattern the surrounding component already uses.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/time.md
+++ b/src/content/docs/architecture/components/time.md
@@ -2,4 +2,127 @@
 title: "Time"
 ---
 
+Like [display](/architecture/components/display) and [touchscreen](/architecture/components/touchscreen), `time` is
+not a Home Assistant entity type - it's a hardware/utility base that provides the device's wall-clock time. A `time`
+platform's only job is to figure out the current time (from an RTC chip, SNTP, Home Assistant, GPS, and so on) and
+make it available to the rest of the device - via `now()`, via `on_time`/cron-style automations, or simply by other
+components calling `id(my_time).now()`.
 
+Like the entity types, `time` is a *platform* base: individual components (for example `sntp`, `ds1307` or
+`homeassistant.time`) register a real-time clock and implement the code that actually obtains the time.
+
+## Python
+
+A time platform lives in a `time.py` file (or a `time/__init__.py` package) inside your component's directory,
+allowing the user to configure it under the top-level `time:` block:
+
+```yaml
+time:
+  - platform: my_component
+    timezone: "Australia/Sydney"
+    on_time:
+      - seconds: 0
+        minutes: 0
+        hours: 0
+        then:
+          - logger.log: "It's midnight!"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import time as time_
+
+my_time_ns = cg.esphome_ns.namespace("my_time")
+MyTime = my_time_ns.class_("MyTime", time_.RealTimeClock)
+```
+
+`time.RealTimeClock` already inherits `cg.PollingComponent`, so no separate component base is needed. The component
+is imported as `time_` to avoid shadowing Python's own `time` module.
+
+### Configuration schema
+
+Extend the shared `time_.TIME_SCHEMA`, which provides the `timezone` option and the `on_time` / `on_time_sync`
+automations, together with `update_interval` (defaulting to 15 minutes) via `cv.polling_component_schema`:
+
+```python
+CONFIG_SCHEMA = time_.TIME_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(MyTime),
+    }
+)
+```
+
+As with the display and touchscreen schema helpers, `TIME_SCHEMA` doesn't take your class as an argument, so you
+supply your own `cv.GenerateID()`.
+
+### Code generation
+
+In `to_code`, register the platform with `time_.register_time()`. Unlike `sensor.new_sensor()` or
+`display.register_display()`, this does *not* call `cg.register_component()` for you - you must do that yourself -
+but it does generate the code for `timezone` and the `on_time`/`on_time_sync` automations:
+
+```python
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await time_.register_time(var, config)
+```
+
+## C++
+
+The C++ class inherits from `time::RealTimeClock`:
+
+```cpp
+#include "esphome/components/time/real_time_clock.h"
+
+namespace esphome::my_time {
+
+class MyTime : public time::RealTimeClock {
+ public:
+  void update() override;
+};
+
+}  // namespace esphome::my_time
+```
+
+### Reporting the time
+
+Whenever you obtain a fresh reading of the current time - from an RTC register read, an SNTP callback, an API
+message from Home Assistant, etc. - call the protected `synchronize_epoch_(epoch)` with the Unix epoch (UTC
+seconds since 1970-01-01):
+
+```cpp
+void MyTime::update() {
+  uint32_t epoch = this->read_epoch_from_hardware_();
+  this->synchronize_epoch_(epoch);
+}
+```
+
+`synchronize_epoch_()` sets the device's system clock (skipping the write if it's already within a second of the
+given value, to avoid clock jitter and log spam) and fires the `on_time_sync` trigger/`add_on_time_sync_callback()`
+listeners. You never need to apply the user's `timezone:` yourself - the base class parses and applies it during
+setup, and every other component that reads the time goes through `RealTimeClock::now()`, which already returns
+timezone-local values.
+
+Not every platform needs to override `update()` at all: some (like `sntp`, which delegates to the underlying OS's
+own SNTP client) only need `setup()` to kick off the sync mechanism, and call `synchronize_epoch_()`/rely on the
+system clock being set for them elsewhere.
+
+### Useful members
+
+- `now()`: the current time in the configured timezone, as an `ESPTime` (year/month/day/hour/minute/second plus
+  day-of-week/day-of-year and an `is_valid()` check).
+- `utcnow()`: the current time with no timezone/DST correction applied.
+- `timestamp_now()`: the raw Unix epoch (`time_t`) - what you'd pass back into `synchronize_epoch_()`.
+- `add_on_time_sync_callback(F &&)`: register a callback to run whenever this clock successfully synchronizes -
+  useful for components that need to defer work until real time is available.
+
+Other components read the current time by depending on `time` and calling `now()` on the configured `time_id`, most
+commonly through the [`time.has_time` condition](https://esphome.io/components/time/#time-has-time-condition) or an
+`on_time` automation, rather than polling a platform directly.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/time.md
+++ b/src/content/docs/architecture/components/time.md
@@ -39,7 +39,7 @@ my_time_ns = cg.esphome_ns.namespace("my_time")
 MyTime = my_time_ns.class_("MyTime", time_.RealTimeClock)
 ```
 
-`time.RealTimeClock` already inherits `cg.PollingComponent`, so no separate component base is needed. The component
+`time_.RealTimeClock` already inherits `cg.PollingComponent`, so no separate component base is needed. The component
 is imported as `time_` to avoid shadowing Python's own `time` module.
 
 ### Configuration schema

--- a/src/content/docs/architecture/components/touchscreen.md
+++ b/src/content/docs/architecture/components/touchscreen.md
@@ -2,4 +2,133 @@
 title: "Touchscreen"
 ---
 
+Like [display](/architecture/components/display), `touchscreen` is not a Home Assistant entity type - it's a
+hardware/utility base for reading a touch-sensitive panel. It reports one or more touch points (position, and
+optionally pressure), attaches to a [display](/architecture/components/display) so it can translate raw controller
+coordinates into on-screen pixel coordinates, and fires triggers/dispatches to listeners (for example
+`binary_sensor` platforms such as `touchscreen_binary_sensor`, or LVGL's input driver) when a touch starts, moves, or
+ends.
 
+Like the entity types, `touchscreen` is a *platform* base: individual components (for example `xpt2046`, `ft5x06` or
+`gt911`) register a touchscreen and implement the code that reads the touch controller.
+
+## Python
+
+A touchscreen platform lives in a `touchscreen.py` file (or a `touchscreen/__init__.py` package) inside your
+component's directory, allowing the user to configure it under the top-level `touchscreen:` block:
+
+```yaml
+touchscreen:
+  - platform: my_component
+    display: my_display
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import touchscreen
+
+my_touchscreen_ns = cg.esphome_ns.namespace("my_touchscreen")
+MyTouchscreen = my_touchscreen_ns.class_("MyTouchscreen", touchscreen.Touchscreen)
+```
+
+`touchscreen.Touchscreen` already inherits `cg.PollingComponent`, so no separate component base is needed.
+
+### Configuration schema
+
+Use the `touchscreen.touchscreen_schema()` helper. It returns a schema pre-populated with the options common to
+every touchscreen - the `display` it's attached to, `transform` (`swap_xy`/`mirror_x`/`mirror_y`), `calibration`,
+`touch_timeout`, and the `on_touch`/`on_update`/`on_release` automations - plus `update_interval` via
+`cv.polling_component_schema`:
+
+```python
+CONFIG_SCHEMA = touchscreen.touchscreen_schema(
+    default_touch_timeout="30ms",
+).extend(
+    {
+        cv.GenerateID(): cv.declare_id(MyTouchscreen),
+        cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_schema,
+    }
+)
+```
+
+`touchscreen_schema()` also takes optional `calibration_required` and `defaults` arguments, used by drivers whose
+controller cannot be sensibly used without a `calibration:` block configured (or that ship known-good calibration
+defaults). As with the display schema helpers, you supply your own `cv.GenerateID()` here.
+
+### Code generation
+
+In `to_code`, register the touchscreen with `touchscreen.register_touchscreen()`. This calls
+`cg.register_component()` for you *and* generates the code for all of the common options (attaching the display,
+transform, calibration, automations):
+
+```python
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await touchscreen.register_touchscreen(var, config)
+
+    if interrupt_pin := config.get(CONF_INTERRUPT_PIN):
+        pin = await cg.gpio_pin_expression(interrupt_pin)
+        cg.add(var.set_interrupt_pin(pin))
+```
+
+## C++
+
+The C++ class inherits from `touchscreen::Touchscreen`:
+
+```cpp
+#include "esphome/components/touchscreen/touchscreen.h"
+
+namespace esphome::my_touchscreen {
+
+class MyTouchscreen : public touchscreen::Touchscreen {
+ public:
+  void setup() override;
+
+ protected:
+  void update_touches() override;
+};
+
+}  // namespace esphome::my_touchscreen
+```
+
+### Reporting touches
+
+The one method you *must* implement is the protected `update_touches()`. The base class calls it (from its own
+`loop()`, whenever the interrupt pin fired or, if no interrupt is configured, on every `update()` poll) to ask you
+to read the controller. For every point currently touched, call `add_raw_touch_position_(id, x_raw, y_raw[, z_raw])`
+with the *raw* coordinates straight from the hardware:
+
+```cpp
+void MyTouchscreen::update_touches() {
+  if (!this->is_touched_by_hardware_()) {
+    return;
+  }
+  int16_t x_raw = this->read_x_();
+  int16_t y_raw = this->read_y_();
+  this->add_raw_touch_position_(0, x_raw, y_raw);
+}
+```
+
+You never call `publish_state()` yourself - `add_raw_touch_position_()` handles everything downstream. It applies
+the configured `swap_xy`/`mirror_x`/`mirror_y` transform and `calibration:` range, scales the result into the
+attached display's pixel dimensions, and stores it. Once `update_touches()` returns, the base class fires
+`on_touch`/`on_update`/`on_release` and dispatches to any registered `TouchListener`s (as `TouchPoint`s) for you - if
+you don't call `add_raw_touch_position_()` for a point that was previously touched, the base class treats it as
+released.
+
+### Useful members
+
+- `get_touch()` / `get_touches()`: the most recently reported touch point(s), already calibrated and scaled to
+  display coordinates.
+- `get_display()`: the `display::Display *` this touchscreen is attached to, useful if you need its dimensions.
+- `register_listener(TouchListener *)`: lets other components (like a binary sensor platform) subscribe to
+  `touch()`/`update()`/`release()` callbacks instead of using the YAML automations.
+- `attach_interrupt_(pin, type)`: a protected helper for drivers with an IRQ pin - it wires the pin so a hardware
+  interrupt sets an internal flag, letting `loop()` call `update_touches()` immediately instead of waiting for the
+  next poll.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/valve.md
+++ b/src/content/docs/architecture/components/valve.md
@@ -2,4 +2,228 @@
 title: "Valve"
 ---
 
+The `valve` component is one of ESPHome's core [entity](/architecture/components/index) types. A valve represents
+anything that opens and closes and can optionally be moved to a position - a water shutoff valve, a gas valve, an
+irrigation valve, and so on. It is a *controllable* entity: in addition to reporting its current position it accepts
+open/close/stop/toggle commands from the front-end (Home Assistant, the web server, MQTT, etc.).
 
+`valve` is closely modeled on [cover](/architecture/components/cover), but simpler: it has no `tilt` concept, since
+valves only ever open and close (optionally to an intermediate position).
+
+Like the other entity types, `valve` is a *platform* base. Individual components (for example a relay-driven shutoff
+valve or a motorized ball valve) register a valve and implement the logic that actually drives the hardware.
+
+## Python
+
+A valve platform lives in a `valve.py` file (or a `valve/__init__.py` package) inside your component's directory. This
+file name tells ESPHome that the component provides a `valve` platform, allowing the user to configure it under the
+`valve:` block:
+
+```yaml
+valve:
+  - platform: my_component
+    name: "My Valve"
+```
+
+The typical imports and class declaration look like this:
+
+```python
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import valve
+
+my_valve_ns = cg.esphome_ns.namespace("my_valve")
+MyValve = my_valve_ns.class_("MyValve", valve.Valve, cg.Component)
+```
+
+Note that `MyValve` inherits from both `valve.Valve` and a component base (`cg.Component` here).
+
+### Configuration schema
+
+Use the `valve.valve_schema()` helper. It returns a schema pre-populated with all of the options common to every
+valve - `name`, `id`, `icon`, `device_class`, `entity_category`, the `on_open` / `on_closed` automations, and so on:
+
+```python
+CONFIG_SCHEMA = valve.valve_schema(MyValve).extend(cv.COMPONENT_SCHEMA)
+```
+
+Passing your class (`MyValve`) as the first argument tells the helper which class to declare the ID for, so you do not
+need a separate `cv.GenerateID()`.
+
+### Code generation
+
+In `to_code`, use the `valve.new_valve()` helper. It calls `cg.new_Pvariable()` for you *and* generates all the code to
+apply the common valve options from the configuration:
+
+```python
+async def to_code(config):
+    var = await valve.new_valve(config)
+    await cg.register_component(var, config)
+```
+
+If your component owns a valve as a child (rather than *being* a valve), use `await valve.register_valve(var, config)`
+instead, having declared the ID yourself.
+
+## C++
+
+The C++ class inherits from `valve::Valve` alongside its component base:
+
+```cpp
+#include "esphome/core/component.h"
+#include "esphome/components/valve/valve.h"
+
+namespace esphome::my_valve {
+
+class MyValve : public valve::Valve, public Component {
+ public:
+  void dump_config() override;
+  valve::ValveTraits get_traits() override;
+
+ protected:
+  void control(const valve::ValveCall &call) override;
+};
+
+}  // namespace esphome::my_valve
+```
+
+### Command flow
+
+As with [cover](/architecture/components/cover#command-flow), a valve command is built up as a `ValveCall` object: the
+front-end (or your own code) calls `make_call()` to get one, sets whichever fields it wants to change
+(`set_position()`, `set_command_open()`, `set_stop()`, ...), and then calls `perform()` on it. This in turn dispatches
+to your protected virtual `control()` method with the finished call.
+
+The two methods you *must* implement are `control(const ValveCall &call)` and `get_traits()`.
+
+```cpp
+void MyValve::control(const ValveCall &call) {
+  if (call.get_stop()) {
+    this->stop_hardware_();
+    this->current_operation = VALVE_OPERATION_IDLE;
+    this->publish_state();
+  }
+
+  if (call.get_position().has_value()) {
+    float pos = *call.get_position();
+    this->move_to_position_(pos);
+    this->position = pos;
+    this->publish_state();
+  }
+}
+
+valve::ValveTraits MyValve::get_traits() {
+  auto traits = valve::ValveTraits();
+  traits.set_supports_position(false);
+  traits.set_supports_stop(false);
+  traits.set_is_assumed_state(false);
+  return traits;
+}
+```
+
+A few important details:
+
+- Inspect `call.get_position()` and `call.get_stop()` to find out what the caller actually asked for; only the fields
+  the caller set will be present (`get_position()` is an `optional<float>`, so check `has_value()` before
+  dereferencing).
+- `get_position()` ranges from `0.0` (`VALVE_CLOSED`) to `1.0` (`VALVE_OPEN`) - use these constants rather than the raw
+  literals where it improves readability. A simple binary valve will only ever be commanded to one of these two
+  extremes.
+- After driving the hardware, update `this->position` and set `this->current_operation` before calling
+  `publish_state()`, so the front-end sees an accurate, up-to-date state.
+- `get_traits()` tells the front-end what the valve can do - whether it supports a continuous `position`, being
+  stopped mid-move, or only reports an *assumed* state (see below). Report only the capabilities your hardware
+  actually has; a simple on/off shutoff valve should leave `supports_position` and `supports_stop` false.
+
+### Assumed state
+
+If your valve cannot read back the real hardware position (so the reported position is only what ESPHome last
+commanded), set `traits.set_is_assumed_state(true)` in `get_traits()`. The front-end will then show separate open/close
+controls rather than trusting the reported position as ground truth.
+
+### Useful members
+
+- `position`: the current reported position, `0.0` (closed) to `1.0` (open). Use `VALVE_OPEN` / `VALVE_CLOSED` for the
+  extremes.
+- `current_operation`: one of `VALVE_OPERATION_IDLE`, `VALVE_OPERATION_OPENING`, `VALVE_OPERATION_CLOSING`.
+- `is_fully_open()` / `is_fully_closed()`: convenience helpers comparing `position` against `1.0` / `0.0`.
+- `publish_state(bool save = true)`: report the current `position`/`current_operation` to the front-end; pass
+  `save = false` to skip persisting the state to flash.
+- `LOG_VALVE(prefix, type, obj)`: a convenience macro for `dump_config()` that logs the valve in the standard format.
+
+## Exposing multiple valves from one component
+
+Hardware often controls more than one valve - an irrigation controller, for example, might drive a separate valve for
+each watering zone. There are two established ways to model this. Both are valid and both are widely used in-tree -
+which one fits depends on how the hardware itself is shaped, so read the two together and pick the one that
+describes your device more honestly.
+
+### A hub plus a `type` on the platform
+
+If your component already has a top-level hub, let the user add one `valve:` entry per zone, distinguished by a
+`type` key via `cv.typed_schema()`:
+
+```yaml
+valve:
+  - platform: my_hub
+    type: zone_1
+    name: "Zone 1"
+  - platform: my_hub
+    type: zone_2
+    name: "Zone 2"
+```
+
+```python
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "zone_1": valve.valve_schema(MyHubZoneValve).extend(_HUB_ID_SCHEMA),
+        "zone_2": valve.valve_schema(MyHubZoneValve).extend(_HUB_ID_SCHEMA),
+    },
+    key=CONF_TYPE,
+)
+
+
+async def to_code(config):
+    var = await valve.new_valve(config)
+    await cg.register_parented(var, config[CONF_MY_HUB_ID])
+```
+
+Each zone is a first-class platform entry with the full set of per-entity options, adding a new zone later is purely
+additive, and different zones can use different C++ classes if they need to.
+
+### Sub-configs on a single platform entry
+
+Some components instead nest a small, fixed set of valves under one platform entry, each an inline
+`cv.Optional(CONF_FILL): valve.valve_schema()` - note `valve_schema()` called *without* a class argument. There is no
+`SUB_VALVE` macro (`SUB_*` exists only for `binary_sensor`, `button`, `number`, `select`, `sensor`, `switch` and
+`text_sensor`), so declare the pointer member and setter by hand, and null-check before use since the user may
+configure only one of them:
+
+```cpp
+class MyValveDevice final : public Component {
+ public:
+  void set_fill_valve(valve::Valve *fill_valve) { this->fill_valve_ = fill_valve; }
+
+ protected:
+  valve::Valve *fill_valve_{nullptr};
+};
+```
+
+See [Exposing multiple sensors from one component](/architecture/components/sensor#exposing-multiple-sensors-from-one-component)
+for a fully worked example of both patterns, including the matching Python schema and `to_code`.
+
+### Choosing between them
+
+Neither pattern is deprecated; they express different relationships between a device and the valves it controls, so
+let the hardware decide:
+
+- **Sub-configs** fit a small, fixed set of valves on a single device - one physical device maps to one YAML block,
+  which is easier to read.
+- **A hub plus `type`** fits when a top-level hub already exists to describe the connection, and the set of valves is
+  large or open-ended (such as an irrigation controller's zones), or different valves need different update
+  strategies.
+
+If both descriptions fit equally well, follow whichever pattern the surrounding component already uses. In a new
+component with no hub, sub-configs are usually the smaller change.
+
+For everything else, the component implements the usual set of methods
+[as described here](/architecture/components/index#common-methods).

--- a/src/content/docs/architecture/components/valve.md
+++ b/src/content/docs/architecture/components/valve.md
@@ -88,18 +88,18 @@ class MyValve : public valve::Valve, public Component {
 
 ### Command flow
 
-As with [cover](/architecture/components/cover#command-flow), a valve command is built up as a `ValveCall` object: the
+As with [cover](/architecture/components/cover#command-flow), a valve command is built up as a `valve::ValveCall` object: the
 front-end (or your own code) calls `make_call()` to get one, sets whichever fields it wants to change
 (`set_position()`, `set_command_open()`, `set_stop()`, ...), and then calls `perform()` on it. This in turn dispatches
 to your protected virtual `control()` method with the finished call.
 
-The two methods you *must* implement are `control(const ValveCall &call)` and `get_traits()`.
+The two methods you *must* implement are `control(const valve::ValveCall &call)` and `get_traits()`.
 
 ```cpp
-void MyValve::control(const ValveCall &call) {
+void MyValve::control(const valve::ValveCall &call) {
   if (call.get_stop()) {
     this->stop_hardware_();
-    this->current_operation = VALVE_OPERATION_IDLE;
+    this->current_operation = valve::VALVE_OPERATION_IDLE;
     this->publish_state();
   }
 
@@ -125,7 +125,7 @@ A few important details:
 - Inspect `call.get_position()` and `call.get_stop()` to find out what the caller actually asked for; only the fields
   the caller set will be present (`get_position()` is an `optional<float>`, so check `has_value()` before
   dereferencing).
-- `get_position()` ranges from `0.0` (`VALVE_CLOSED`) to `1.0` (`VALVE_OPEN`) - use these constants rather than the raw
+- `get_position()` ranges from `0.0` (`valve::VALVE_CLOSED`) to `1.0` (`valve::VALVE_OPEN`) - use these constants rather than the raw
   literals where it improves readability. A simple binary valve will only ever be commanded to one of these two
   extremes.
 - After driving the hardware, update `this->position` and set `this->current_operation` before calling
@@ -142,9 +142,9 @@ controls rather than trusting the reported position as ground truth.
 
 ### Useful members
 
-- `position`: the current reported position, `0.0` (closed) to `1.0` (open). Use `VALVE_OPEN` / `VALVE_CLOSED` for the
+- `position`: the current reported position, `0.0` (closed) to `1.0` (open). Use `valve::VALVE_OPEN` / `valve::VALVE_CLOSED` for the
   extremes.
-- `current_operation`: one of `VALVE_OPERATION_IDLE`, `VALVE_OPERATION_OPENING`, `VALVE_OPERATION_CLOSING`.
+- `current_operation`: one of `valve::VALVE_OPERATION_IDLE`, `valve::VALVE_OPERATION_OPENING`, `valve::VALVE_OPERATION_CLOSING`.
 - `is_fully_open()` / `is_fully_closed()`: convenience helpers comparing `position` against `1.0` / `0.0`.
 - `publish_state(bool save = true)`: report the current `position`/`current_operation` to the front-end; pass
   `save = false` to skip persisting the state to flash.


### PR DESCRIPTION
The twenty-two pages under the **Entity base classes** section of the navigation tree were stubs containing only frontmatter. Anyone following the tree down from the component architecture page hit a dead end, which is a shame because these are exactly the pages a first-time component author needs.

Each page now covers what the entity or hardware base actually is, the Python platform (the `*_schema()` helper and codegen), the C++ base class alongside the method(s) an implementer overrides, and a short list of genuinely useful base-class members. Everything was written against the current headers and `__init__.py` files rather than from memory, and each page links the matching [starter component](https://github.com/esphome/starter-components) where one exists.

Each entity page also gained a section on the two ways a component can expose more than one entity: sub-configs nested under a single platform entry (as `dht` does), and a top-level hub with a `type` key via `cv.typed_schema` (as `sendspin` does). Both are presented as valid, closing with guidance on which suits a given device shape rather than a blanket recommendation. `output` gets its own variant of this, since multi-channel outputs use a per-channel key (`pca9685`) or `type` for heterogeneous channels (`modbus_controller`) and never sub-configs.

A few details worth calling out for review, since they are easy to get wrong and are now asserted in the docs:

- The `class_` argument is optional on `sensor_schema()`, `binary_sensor_schema()`, `text_sensor_schema()`, `text_schema()`, `lock_schema()`, `valve_schema()` and `event_schema()`, but required on `switch`, `number`, `select`, `button`, `cover`, `fan`, `climate`, `media_player` and `alarm_control_panel`. Only `sensor`, `binary_sensor`, `text_sensor` and `event` have non-abstract bases where omitting it genuinely works, which is why `dht` can call `sensor_schema()` bare. `button.md` spells this out, including the note that the Python-side enforcement is inconsistent and partly historical.
- `SUB_*` macros exist for exactly seven types (`BINARY_SENSOR`, `BUTTON`, `NUMBER`, `SELECT`, `SENSOR`, `SWITCH`, `TEXT_SENSOR`) and no others, so the remaining pages show a hand-written pointer member and setter instead.
- `light.md` keeps the `LightOutput` versus core-owned `LightState` distinction throughout, and notes that `new_light()` already registers the `LightState` as a component.

`display`, `speaker`, `time` and `touchscreen` are documented as hardware/utility bases and deliberately skip the multi-entity section, since the pattern does not apply to them the same way. No navigation or config changes were needed, as the sidebar already listed every page.