### PR TITLE
Document platform components and the EXPAND_PLATFORM_CONFIG hook

### DIFF
--- a/src/content/docs/architecture/components/index.md
+++ b/src/content/docs/architecture/components/index.md
@@ -192,6 +192,86 @@ any other components and potentially fail the validation stage if an important d
 For example, many components that rely on `uart` can use the `FINAL_VALIDATE_SCHEMA` to ensure that the `tx_pin` and/or
 `rx_pin` are configured.
 
+### Platform components
+
+Some components are **platform components**: instead of a single configuration block, the top-level YAML key holds a
+list of entries, each selecting a *platform* that provides its own `CONFIG_SCHEMA`/`to_code`. `sensor`, `switch` and
+`image` are all platform components:
+
+```yaml
+image:
+  - platform: file
+    file: "image.png"
+    id: my_image
+```
+
+A component opts into this by setting `IS_PLATFORM_COMPONENT = True` in its `__init__.py`. Each platform then lives
+in its own component package, in a module named after the platform component's domain --
+`esphome/components/<platform>/<domain>.py` -- exposing its own `CONFIG_SCHEMA` and `to_code` exactly like a regular
+component. For example, `platform: file` under `image:` resolves to `esphome/components/file/image.py`.
+
+Two optional hooks on the platform component's own `__init__.py` module let it reshape the raw domain config -- the
+list of `platform:`-tagged entries -- *before* any individual entry's `CONFIG_SCHEMA` runs or its IDs are registered:
+
+#### `LEGACY_CONFIG_MIGRATE`
+
+A removable deprecation shim: rewrites a pre-platform-component config shape (for example, a bare list or a
+monolithic dict your component used to accept before it became a platform component) into the normalized
+`platform:`-tagged list, logging a one-time deprecation warning. Delete it, along with any code that only exists to
+understand the old shape, once its removal version has passed.
+
+```python
+def migrate_legacy_config(config: object) -> list[dict] | None:
+    if _is_already_platform_tagged(config):
+        return None  # Nothing to do.
+    _LOGGER.warning("... deprecated ...")
+    return [{"platform": "file", **entry} for entry in _flatten(config)]
+
+
+LEGACY_CONFIG_MIGRATE = migrate_legacy_config
+```
+
+#### `EXPAND_PLATFORM_CONFIG`
+
+A permanent (non-deprecated) counterpart: lets any platform entry -- for any platform the component provides --
+expand into multiple entries. `image` uses this so a single entry can provide `defaults:` (options merged into
+every image) plus `files:` (a list of per-image overrides), instead of repeating shared options on every entry. It
+only has to be implemented once, in the base `image` component, and every platform it provides (`file`, `animation`,
+`online_image`) gets the feature for free.
+
+```python
+def expand_platform_config(config: list[dict]) -> list[dict]:
+    result = []
+    for entry in config:
+        if "files" not in entry:
+            result.append(entry)
+            continue
+        defaults = entry.get("defaults", {})
+        result.extend(
+            {"platform": entry["platform"], **defaults, **file_entry}
+            for file_entry in entry["files"]
+        )
+    return result
+
+
+EXPAND_PLATFORM_CONFIG = expand_platform_config
+```
+
+Contract:
+
+- Do only structural dict manipulation here -- leave semantic validation (for example, "is this key valid for this
+  platform") to each platform's own `CONFIG_SCHEMA`, which still runs on every entry the hook returns.
+- To reject malformed input, raise `cv.Invalid`, optionally with `path=[index]` where `index` is the offending
+  entry's position in the *input* list, so the error is anchored to that entry rather than to the whole domain. Do
+  not raise other exception types for user-facing errors -- they will surface as an unhandled traceback rather than
+  a config error.
+- The return value must always be a `list`. Returning anything else is treated as a bug in the component, not a
+  user configuration error.
+- It runs once per domain, after `LEGACY_CONFIG_MIGRATE` (if defined) and after the domain's raw config has been
+  normalized into a list, but before any entry's `CONFIG_SCHEMA`, `FINAL_VALIDATE_SCHEMA`, or ID registration.
+
+See `esphome/components/image/__init__.py` for the full implementation this is based on.
+
 ## C++ component structure
 
 Given the example Python code above, let's consider the following C++ code:


### PR DESCRIPTION
Platform components (sensor, switch, image, ...) and the structural hooks available to their __init__.py (LEGACY_CONFIG_MIGRATE, and the new EXPAND_PLATFORM_CONFIG used by image's defaults:/files: support) were undocumented here. Add a Platform components section covering both, with the contract for EXPAND_PLATFORM_CONFIG: structural-only, raise cv.Invalid (with path=[index]) to reject input, must return a list.