### PR TITLE
Document the loop blocking warning and UnavoidableBlockingScope

### DIFF
--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -328,7 +328,7 @@ void MyRadio::setup() {
 
 When the scope ends it moves the pass start time forward by the time spent inside it, so the guard still reports everything else in the pass and the component's threshold does not ratchet up over the one step nothing can be done about. Code after the scope that reads `App.get_loop_component_start_time()` sees the adjusted time, which is closer to "now" than the original pass start.
 
-Never use it to paper over a problem that can be solved. A slow driver call, a loop that could be a state machine, a computation that could be cached or deferred, a blocking read that could be polled: those are what the warning exists to find, and wrapping them hides the bug instead of fixing it. If in doubt, leave the warning in. The scope does not change the `Setup ... took N ms` line logged at boot, which still reports the full setup time.
+Never use it to paper over a problem that can be solved. A slow driver call, a loop that could be a state machine, a computation that could be cached or deferred, a blocking read that could be polled: those are what the warning exists to find, and wrapping them hides the bug instead of fixing it. If in doubt, leave the warning in. Use it from the main loop task only, and keep the work inside it under the watchdog timeout, since the watchdog is not fed inside the scope. The scope does not change the `Setup ... took N ms` line logged at boot, which still reports the full setup time.
 
 ## Waking the Main Loop from Background Threads
 

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -314,7 +314,7 @@ The threshold ratchets: after a warning the component's own threshold becomes th
 
 ### `UnavoidableBlockingScope`
 
-A few steps done from a loop pass have no shorter form and cannot be split across passes: turning on the ESP32 Bluetooth controller once the network is up, reconnecting Wi-Fi after the link dropped, generating the key pair for the next encrypted API connection. Wrapping only that step in an `UnavoidableBlockingScope` (from `esphome/core/application.h`) leaves it out of the measurement for the current pass:
+A few steps done from a loop pass have no shorter form and cannot be split across passes: turning on a radio, the first Wi-Fi connect, a key generation whose cost is the algorithm itself. Wrapping only that step in an `UnavoidableBlockingScope` (from `esphome/core/application.h`) leaves it out of the measurement for the current pass:
 
 ```cpp
 void MyComponent::loop() {

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -314,7 +314,7 @@ The threshold ratchets: after a warning the component's own threshold becomes th
 
 ### `UnavoidableBlockingScope`
 
-A few steps have no shorter form and cannot be split across passes: enabling a radio, the first connect of a network stack, a key generation whose cost is the algorithm itself. When such a step runs from `loop()`, `update()` or a scheduler callback, wrapping only that step in an `UnavoidableBlockingScope` (from `esphome/core/application.h`) leaves it out of the measurement for the current pass:
+A few steps done from a loop pass have no shorter form and cannot be split across passes: turning on the ESP32 Bluetooth controller once the network is up, reconnecting Wi-Fi after the link dropped, generating the key pair for the next encrypted API connection. Wrapping only that step in an `UnavoidableBlockingScope` (from `esphome/core/application.h`) leaves it out of the measurement for the current pass:
 
 ```cpp
 void MyComponent::loop() {

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -314,7 +314,7 @@ The threshold ratchets: after a warning the component's own threshold becomes th
 
 ### `UnavoidableBlockingScope`
 
-A few steps have no shorter form and cannot be split across passes: enabling a radio, the first connect of a network stack, a key generation whose cost is the algorithm itself. Wrapping only that step in an `UnavoidableBlockingScope` (from `esphome/core/application.h`) leaves it out of the measurement for the current pass:
+A few steps have no shorter form and cannot be split across passes: enabling a radio, the first connect of a network stack, a key generation whose cost is the algorithm itself. When such a step runs from `loop()`, `update()` or a scheduler callback, wrapping only that step in an `UnavoidableBlockingScope` (from `esphome/core/application.h`) leaves it out of the measurement for the current pass:
 
 ```cpp
 void MyComponent::loop() {

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -304,7 +304,7 @@ A `loop()` method costs one pointer in the application's `looping_components_` l
 
 ## The Loop Blocking Warning
 
-Every component `loop()`, `update()`, `setup()` and scheduled callback runs under a guard that measures how long it held the main loop. When one pass exceeds the threshold (`WARN_IF_BLOCKING_OVER_MS`, 50 ms by default) the log shows:
+Every component `loop()`, `update()` and scheduled callback runs under a guard that measures how long it held the main loop; `setup()` is not measured, its time is only reported in the `Setup ... took N ms` line. When one pass exceeds the threshold (`WARN_IF_BLOCKING_OVER_MS`, 50 ms by default) the log shows:
 
 ```text
 [W][component:XXX]: wifi took a long time for an operation (73 ms), max is 50 ms
@@ -314,27 +314,27 @@ The threshold ratchets: after a warning the component's own threshold becomes th
 
 ### `UnavoidableBlockingScope`
 
-A few steps have no shorter form and cannot be split across passes: bringing up a radio, the first connect of a network stack, a key generation whose cost is the algorithm itself. Wrapping only that step in an `UnavoidableBlockingScope` (from `esphome/core/application.h`) leaves it out of the measurement for the current pass:
+A few steps have no shorter form and cannot be split across passes: enabling a radio, the first connect of a network stack, a key generation whose cost is the algorithm itself. Wrapping only that step in an `UnavoidableBlockingScope` (from `esphome/core/application.h`) leaves it out of the measurement for the current pass:
 
 ```cpp
-void MyRadio::setup() {
-  {
+void MyComponent::loop() {
+  if (this->needs_key_) {
     UnavoidableBlockingScope scope;
-    this->bring_up_radio_();  // 120 ms of driver initialisation, nothing to split
+    this->generate_key_();  // 60 ms of arithmetic, nothing to split
   }
-  this->configure_();  // still measured
+  this->poll_();  // still measured
 }
 ```
 
-When the scope ends it moves the pass start time forward by the time spent inside it, so the guard still reports everything else in the pass and the component's threshold does not ratchet up over the one step nothing can be done about. Code after the scope that reads `App.get_loop_component_start_time()` sees the adjusted time, which is closer to "now" than the original pass start.
+When the scope ends it moves the pass start time forward by the time spent inside it, so the guard still reports everything else in the pass and the component's threshold does not ratchet up over the one step nothing can be done about. Code after the scope that reads `App.get_loop_component_start_time()` sees the adjusted time, which is closer to "now" than the original pass start. Scopes may nest; the outermost one decides how much of the pass is left out.
 
 Never use it to paper over a problem that can be solved. A slow driver call, a loop that could be a state machine, a computation that could be cached or deferred, a blocking read that could be polled: those are what the warning exists to find, and wrapping them hides the bug instead of fixing it. If in doubt, leave the warning in.
 
 > [!WARNING]
 >
+> - Only work timed by the guard is affected: a component's `loop()` or `update()`, or a scheduler callback. The scope does nothing in `setup()`.
 > - Use the scope from the main loop task only.
 > - The watchdog is not fed inside the scope, so the work must still finish within the watchdog timeout.
-> - The `Setup ... took N ms` line logged at boot is not affected and still reports the full setup time.
 
 ## Waking the Main Loop from Background Threads
 

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -302,6 +302,34 @@ A `loop()` method costs one pointer in the application's `looping_components_` l
 - **`set_timeout`** — one-shots and self-rescheduling timers with variable delays. Don't chain it as a hand-rolled `set_interval`.
 - **`defer`** — run-once on the next main-loop iteration; use it to break recursion or escape interrupt context, not as a task queue.
 
+## The Loop Blocking Warning
+
+Every component `loop()`, `update()`, `setup()` and scheduled callback runs under a guard that measures how long it held the main loop. When one pass exceeds the threshold (`WARN_IF_BLOCKING_OVER_MS`, 50 ms by default) the log shows:
+
+```text
+[W][component:420]: wifi took a long time for an operation (73 ms), max is 50 ms
+```
+
+The threshold ratchets: after a warning the component's own threshold becomes the measured time plus 10 ms, so a component that blocks once for 70 ms during boot is only reported again when it blocks for more than 80 ms. The warning is the main tool for finding work that should be a state machine, a cached value or a `set_timeout`; fix the cause rather than the message.
+
+### `UnavoidableBlockingScope`
+
+A few steps have no shorter form and cannot be split across passes: bringing up a radio, the first connect of a network stack, a key generation whose cost is the algorithm itself. Wrapping only that step in an `UnavoidableBlockingScope` (from `esphome/core/application.h`) leaves it out of the measurement for the current pass:
+
+```cpp
+void MyRadio::setup() {
+  {
+    UnavoidableBlockingScope scope;
+    this->bring_up_radio_();  // 120 ms of driver initialisation, nothing to split
+  }
+  this->configure_();  // still measured
+}
+```
+
+When the scope ends it moves the pass start time forward by the time spent inside it, so the guard still reports everything else in the pass and the component's threshold does not ratchet up over the one step nothing can be done about. Code after the scope that reads `App.get_loop_component_start_time()` sees the adjusted time, which is closer to "now" than the original pass start.
+
+Never use it to paper over a problem that can be solved. A slow driver call, a loop that could be a state machine, a computation that could be cached or deferred, a blocking read that could be polled: those are what the warning exists to find, and wrapping them hides the bug instead of fixing it. If in doubt, leave the warning in. The scope does not change the `Setup ... took N ms` line logged at boot, which still reports the full setup time.
+
 ## Waking the Main Loop from Background Threads
 
 For components that receive events in background threads/FreeRTOS tasks (BLE callbacks, network events, platform callbacks, etc.) and need low-latency processing, use `App.wake_loop_threadsafe()` to immediately wake the main loop instead of waiting 0-16ms for the next loop timeout.

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -310,7 +310,7 @@ Every component `loop()`, `update()` and scheduled callback runs under a guard t
 [W][component:XXX]: wifi took a long time for an operation (73 ms), max is 50 ms
 ```
 
-The threshold ratchets: after a warning the component's own threshold becomes the measured time plus 10 ms, so a component that blocks once for 73 ms is only reported again when it blocks for more than 83 ms, for the rest of the run. The warning is the main tool for finding work that should be a state machine, a cached value or a `set_timeout`; fix the cause rather than the message.
+The threshold ratchets: after a warning the component's own threshold becomes the measured time plus 10 ms, rounded down to a 10 ms step, so a component that blocks once for 73 ms is only reported again when it blocks for more than 80 ms, for the rest of the run. The warning is the main tool for finding work that should be a state machine, a cached value or a `set_timeout`; fix the cause rather than the message.
 
 ### `UnavoidableBlockingScope`
 

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -404,4 +404,5 @@ void IRAM_ATTR MyComponent::gpio_isr(MyComponent *arg) {
 
 - Component Loop Control: [`esphome/core/component.h`](https://github.com/esphome/esphome/blob/dev/esphome/core/component.h) and [`esphome/core/component.cpp`](https://github.com/esphome/esphome/blob/dev/esphome/core/component.cpp)
 - Wake Loop Threadsafe: PR [#11681](https://github.com/esphome/esphome/pull/11681)
+- Loop Blocking Warning and `UnavoidableBlockingScope`: PR [#19020](https://github.com/esphome/esphome/pull/19020)
 - [Socket Consumption API](/architecture/components/socket_consumption_api) - For components that use network sockets

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -326,7 +326,7 @@ void MyComponent::loop() {
 }
 ```
 
-When the scope ends it moves the pass start time forward by the time spent inside it, so the guard still reports everything else in the pass and the component's threshold does not ratchet up over the one step nothing can be done about. Code after the scope that reads `App.get_loop_component_start_time()` sees the adjusted time, which is closer to "now" than the original pass start. Scopes may nest; the outermost one decides how much of the pass is left out.
+When the scope ends it moves the pass start time forward by the time spent inside it, so the guard still reports everything else in the pass and the component's threshold does not ratchet up over the one step nothing can be done about. Code after the scope that reads `App.get_loop_component_start_time()` sees the adjusted time, which is closer to "now" than the original pass start; elapsed time computed from it across the scope leaves out the scoped work, so read `millis()` when the true elapsed time matters. Scopes may nest; the outermost one decides how much of the pass is left out.
 
 Never use it to paper over a problem that can be solved. A slow driver call, a loop that could be a state machine, a computation that could be cached or deferred, a blocking read that could be polled: those are what the warning exists to find, and wrapping them hides the bug instead of fixing it. If in doubt, leave the warning in.
 

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -334,7 +334,7 @@ Never use it to paper over a problem that can be solved. A slow driver call, a l
 >
 > - Only work timed by the guard is affected: a component's `loop()` or `update()`, or a scheduler callback. The scope does nothing in `setup()`.
 > - Use the scope from the main loop task only.
-> - The watchdog is not fed inside the scope, so the work must still finish within the watchdog timeout.
+> - The watchdog is not fed inside the scope, so the work must finish within the watchdog timeout, or be paired with a `watchdog::WatchdogManager` (from `esphome/components/watchdog/watchdog.h`) that raises the timeout for the same stretch.
 
 ## Waking the Main Loop from Background Threads
 

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -307,10 +307,10 @@ A `loop()` method costs one pointer in the application's `looping_components_` l
 Every component `loop()`, `update()`, `setup()` and scheduled callback runs under a guard that measures how long it held the main loop. When one pass exceeds the threshold (`WARN_IF_BLOCKING_OVER_MS`, 50 ms by default) the log shows:
 
 ```text
-[W][component:420]: wifi took a long time for an operation (73 ms), max is 50 ms
+[W][component:XXX]: wifi took a long time for an operation (73 ms), max is 50 ms
 ```
 
-The threshold ratchets: after a warning the component's own threshold becomes the measured time plus 10 ms, so a component that blocks once for 70 ms during boot is only reported again when it blocks for more than 80 ms. The warning is the main tool for finding work that should be a state machine, a cached value or a `set_timeout`; fix the cause rather than the message.
+The threshold ratchets: after a warning the component's own threshold becomes the measured time plus 10 ms, so a component that blocks once for 73 ms is only reported again when it blocks for more than 83 ms, for the rest of the run. The warning is the main tool for finding work that should be a state machine, a cached value or a `set_timeout`; fix the cause rather than the message.
 
 ### `UnavoidableBlockingScope`
 
@@ -328,7 +328,13 @@ void MyRadio::setup() {
 
 When the scope ends it moves the pass start time forward by the time spent inside it, so the guard still reports everything else in the pass and the component's threshold does not ratchet up over the one step nothing can be done about. Code after the scope that reads `App.get_loop_component_start_time()` sees the adjusted time, which is closer to "now" than the original pass start.
 
-Never use it to paper over a problem that can be solved. A slow driver call, a loop that could be a state machine, a computation that could be cached or deferred, a blocking read that could be polled: those are what the warning exists to find, and wrapping them hides the bug instead of fixing it. If in doubt, leave the warning in. Use it from the main loop task only, and keep the work inside it under the watchdog timeout, since the watchdog is not fed inside the scope. The scope does not change the `Setup ... took N ms` line logged at boot, which still reports the full setup time.
+Never use it to paper over a problem that can be solved. A slow driver call, a loop that could be a state machine, a computation that could be cached or deferred, a blocking read that could be polled: those are what the warning exists to find, and wrapping them hides the bug instead of fixing it. If in doubt, leave the warning in.
+
+> [!WARNING]
+>
+> - Use the scope from the main loop task only.
+> - The watchdog is not fed inside the scope, so the work must still finish within the watchdog timeout.
+> - The `Setup ... took N ms` line logged at boot is not affected and still reports the full setup time.
 
 ## Waking the Main Loop from Background Threads
 

--- a/src/content/docs/contributing/code.md
+++ b/src/content/docs/contributing/code.md
@@ -459,6 +459,9 @@ In general, we try to avoid use of external libraries.
   - For any [`Component`](https://esphome.io/api/classesphome_1_1_component) (which is nearly everything), the
       well-known `set_timeout` method is also available; this can be a handy alternative to implementing a state
       machine.
+  - ESPHome warns in the log when a component holds the loop for too long; see
+      [The Loop Blocking Warning](/architecture/components/advanced#the-loop-blocking-warning) for how the warning
+      works and the narrow case where `UnavoidableBlockingScope` may be used.
 
 #### Components/platforms and entities
 


### PR DESCRIPTION
Documents the loop blocking warning and the `UnavoidableBlockingScope` added in esphome/esphome#19020: a new section on the advanced components page explaining what the warning measures, how the per component threshold ratchets after a warning, and how the scope moves the pass start forward so one step that cannot be shortened or split is left out while everything else in the pass is still reported; it repeats the rule that the scope is only for radio bring up, first network connect and key generation, never for problems that can be fixed. The contributing code guide gets a one line pointer to the section from the must not block rules.

Pairs with esphome/esphome#19020.
