### PR TITLE
Document set_internal() during setup and its limitations

### DIFF
--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -368,13 +368,35 @@ void IRAM_ATTR MyComponent::gpio_isr(MyComponent *arg) {
 
 ## Hiding Entities at Boot
 
-Prefer the `internal:` YAML key; it is guaranteed and has none of the limitations below. When the decision can only be made at boot, `EntityBase::set_internal(bool)` may be called from `on_boot` at the default priority or from a `setup()` above `setup_priority::AFTER_WIFI`. Calls after setup log an error and are ignored.
+Prefer the `internal:` YAML key; it is guaranteed and has none of the limitations below. When the decision can only be made at boot, `EntityBase::set_internal(bool)` may be called from `on_boot` at the default priority or from a component's `setup()` above `setup_priority::AFTER_WIFI`. Calls after setup are undefined behavior: the flag is still written and an error is logged, and from 2027.3.0 the call is ignored.
 
 ```yaml
 esphome:
   on_boot:
     then:
       - lambda: id(hp2_temperature).set_internal(id(setup_pref).load());
+```
+
+### Waiting for a device handshake
+
+If the answer comes from the device itself, hold setup with `can_proceed()` until it arrives. `Application::setup()` keeps running the loops of components already set up while it waits, so the handshake can proceed, and the API and MQTT have not run yet when the flag is written. Always add a timeout so a missing device does not block boot.
+
+```cpp
+void MyClimate::setup() {
+  this->handshake_started_ = App.get_loop_component_start_time();
+  this->start_handshake_();
+}
+
+void MyClimate::loop() { this->process_uart_data_(); }
+
+bool MyClimate::can_proceed() {
+  if (this->features_known_) {
+    this->zone_2_switch_->set_internal(!this->features_.zones);
+    return true;
+  }
+  // Give up after 10 s and leave the optional entities hidden
+  return App.get_loop_component_start_time() - this->handshake_started_ > 10000;
+}
 ```
 
 Known limitations, not bugs; a PR removing one with no RAM or performance cost would be considered:

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -394,8 +394,8 @@ bool MyClimate::can_proceed() {
     this->zone_2_switch_->set_internal(!this->features_.zones);
     return true;
   }
-  // Give up after 10 s and leave the optional entities hidden
-  return App.get_loop_component_start_time() - this->handshake_started_ > 10000;
+  // Give up after 2 s and leave the optional entities hidden
+  return App.get_loop_component_start_time() - this->handshake_started_ > 2000;
 }
 ```
 

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -368,18 +368,24 @@ void IRAM_ATTR MyComponent::gpio_isr(MyComponent *arg) {
 
 ## Hiding Entities at Boot
 
-Prefer the `internal:` YAML key; it is guaranteed and has none of the limitations below. When the decision can only be made at boot, `EntityBase::set_internal(bool)` may be called from `on_boot` at the default priority or from a component's `setup()` above `setup_priority::AFTER_WIFI`. Calls after setup are undefined behavior: the flag is still written and an error is logged, and from 2027.3.0 the call is ignored.
+Prefer the `internal:` YAML key; it is guaranteed and has none of the limitations below. When the decision can only be made at boot, `EntityBase::set_internal(bool)` may be called from `on_boot` at its default priority or from a component's `setup()` that runs before `setup_priority::AFTER_WIFI` (a numerically higher priority). Requires ESPHome 2026.10.0 or later ([PR #19069](https://github.com/esphome/esphome/pull/19069)). Calls after setup are unsupported: the flag is still written and an error is logged, and from 2027.3.0 the call is ignored.
 
 ```yaml
+globals:
+  - id: second_unit_installed
+    type: bool
+    restore_value: true
+    initial_value: "false"
+
 esphome:
   on_boot:
     then:
-      - lambda: id(hp2_temperature).set_internal(id(setup_pref).load());
+      - lambda: id(unit_2_temperature).set_internal(!id(second_unit_installed));
 ```
 
 ### Waiting for a device handshake
 
-If the answer comes from the device itself, hold setup with `can_proceed()` until it arrives. `Application::setup()` keeps running the loops of components already set up while it waits, so the handshake can proceed, and the API and MQTT have not run yet when the flag is written. Always add a timeout so a missing device does not block boot.
+If the answer comes from the device itself, hold setup with `can_proceed()` until it arrives. `Application::setup()` keeps running the loops of components already set up while it waits, so the handshake can proceed, and the API and MQTT have not run yet when the flag is written. The component must keep the default `setup_priority::DATA` or another priority before `AFTER_WIFI`. Always add a timeout so a missing device does not block boot.
 
 ```cpp
 void MyClimate::setup() {
@@ -389,20 +395,22 @@ void MyClimate::setup() {
 
 void MyClimate::loop() { this->process_uart_data_(); }
 
+// Called from process_uart_data_() once the device has reported its features
+void MyClimate::on_features_(const Features &features) {
+  this->zone_2_switch_->set_internal(!features.zones);
+  this->features_known_ = true;
+}
+
 bool MyClimate::can_proceed() {
-  if (this->features_known_) {
-    this->zone_2_switch_->set_internal(!this->features_.zones);
-    return true;
-  }
-  // Give up after 2 s and leave the optional entities hidden
-  return App.get_loop_component_start_time() - this->handshake_started_ > 2000;
+  // Give up after 2 s; entities then keep their YAML internal: value
+  return this->features_known_ || App.get_loop_component_start_time() - this->handshake_started_ > 2000;
 }
 ```
 
-Known limitations, not bugs; a PR removing one with no RAM or performance cost would be considered:
+Known limitations. These are not bugs, so please do not open issue reports for them; a PR that removes one with no RAM or performance cost would be considered.
 
 - Consumers are not notified, so the flag is decided once per boot.
-- Below `AFTER_WIFI`, MQTT and the API camera listener have already read the flag.
+- After `setup_priority::AFTER_WIFI` the API camera listener has already read the flag; after `setup_priority::AFTER_CONNECTION`, MQTT has too.
 - Un-hiding a YAML `internal: true` entity skips the duplicate name check, and Zigbee never registers it.
 
 ## See Also

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -407,7 +407,9 @@ bool MyClimate::can_proceed() {
 }
 ```
 
-Known limitations. These are not bugs, so please do not open issue reports for them; a PR that removes one with no RAM or performance cost would be considered.
+### Known limitations
+
+These are not bugs, so please do not open issue reports for them; a PR that removes one with no RAM or performance cost would be considered.
 
 - Consumers are not notified, so the flag is decided once per boot.
 - After `setup_priority::AFTER_WIFI` the API camera listener has already read the flag; after `setup_priority::AFTER_CONNECTION`, MQTT has too.

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -368,9 +368,9 @@ void IRAM_ATTR MyComponent::gpio_isr(MyComponent *arg) {
 
 ## Hiding Entities at Boot
 
-`EntityBase::set_internal(bool)` changes whether an entity is exposed outside ESPHome (API, MQTT, web server, Prometheus). It is kept for existing projects that decide the flag at boot and is not recommended for new designs; use the `internal:` YAML key instead. It is only valid before setup finishes: call it from `on_boot` at the default priority, or from a component's `setup()` that runs above `setup_priority::AFTER_WIFI`. Calls after setup log an error and are ignored.
+`EntityBase::set_internal(bool)` changes whether an entity is exposed outside ESPHome (API, MQTT, web server, Prometheus). Prefer the `internal:` YAML key whenever possible: it is guaranteed and has none of the limitations below. Use `set_internal()` only when the decision can only be made at boot. It is only valid before setup finishes: call it from `on_boot` at the default priority, or from a component's `setup()` that runs above `setup_priority::AFTER_WIFI`. Calls after setup log an error and are ignored.
 
-Existing projects use it when one firmware serves several hardware variants and the variant is decided once per boot, for example from a stored preference:
+The typical case is one firmware serving several hardware variants, with the variant decided once per boot from a stored preference:
 
 ```yaml
 esphome:

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -384,7 +384,7 @@ esphome:
 
 ### Limitations
 
-These are by design and will not be changed:
+These are known limitations, not bugs, so please do not open issue reports for them. A PR that removes one with no RAM or performance cost would be considered.
 
 - No consumer is notified of a change, so the flag can only be decided once per boot.
 - A call from a priority below `AFTER_WIFI` still passes the guard, but MQTT (`AFTER_CONNECTION`) and the API camera listener (`AFTER_WIFI`) have already read the flag and keep the old value. An API client that connects while setup is stalled on a slow component has also already listed the entities.

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -368,9 +368,9 @@ void IRAM_ATTR MyComponent::gpio_isr(MyComponent *arg) {
 
 ## Hiding Entities at Boot
 
-`EntityBase::set_internal(bool)` changes whether an entity is exposed outside ESPHome (API, MQTT, web server, Prometheus). It is only valid before setup finishes: call it from `on_boot` at the default priority, or from a component's `setup()` that runs above `setup_priority::AFTER_WIFI`. Calls after setup log an error and are ignored.
+`EntityBase::set_internal(bool)` changes whether an entity is exposed outside ESPHome (API, MQTT, web server, Prometheus). It is kept for existing projects that decide the flag at boot and is not recommended for new designs; use the `internal:` YAML key instead. It is only valid before setup finishes: call it from `on_boot` at the default priority, or from a component's `setup()` that runs above `setup_priority::AFTER_WIFI`. Calls after setup log an error and are ignored.
 
-Use this when one firmware serves several hardware variants and the variant is decided once per boot, for example from a stored preference:
+Existing projects use it when one firmware serves several hardware variants and the variant is decided once per boot, for example from a stored preference:
 
 ```yaml
 esphome:

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -366,8 +366,34 @@ void IRAM_ATTR MyComponent::gpio_isr(MyComponent *arg) {
 }
 ```
 
+## Hiding Entities at Boot
+
+`EntityBase::set_internal(bool)` changes whether an entity is exposed outside ESPHome (API, MQTT, web server, Prometheus). It is only valid before setup finishes: call it from `on_boot` at the default priority, or from a component's `setup()` that runs above `setup_priority::AFTER_WIFI`. Calls after setup log an error and are ignored.
+
+Use this when one firmware serves several hardware variants and the variant is decided once per boot, for example from a stored preference:
+
+```yaml
+esphome:
+  on_boot:
+    then:
+      - lambda: |-
+          bool single_unit = id(setup_pref).load();
+          id(hp2_temperature).set_internal(single_unit);
+          id(hp2_power).set_internal(single_unit);
+```
+
+### Limitations
+
+These are by design and will not be changed:
+
+- No consumer is notified of a change, so the flag can only be decided once per boot.
+- A call from a priority below `AFTER_WIFI` still passes the guard, but MQTT (`AFTER_CONNECTION`) and the API camera listener (`AFTER_WIFI`) have already read the flag and keep the old value. An API client that connects while setup is stalled on a slow component has also already listed the entities.
+- Un-hiding an entity declared `internal: true` in YAML skips the duplicate name check codegen runs for exposed entities, so a name collision can surface at runtime. Entities with only an `id:` are forced internal and use the id as their name.
+- Zigbee codegen skips YAML internal entities entirely, so un-hiding cannot add them to Zigbee.
+
 ## See Also
 
 - Component Loop Control: [`esphome/core/component.h`](https://github.com/esphome/esphome/blob/dev/esphome/core/component.h) and [`esphome/core/component.cpp`](https://github.com/esphome/esphome/blob/dev/esphome/core/component.cpp)
 - Wake Loop Threadsafe: PR [#11681](https://github.com/esphome/esphome/pull/11681)
+- Hiding Entities at Boot: PR [#19069](https://github.com/esphome/esphome/pull/19069)
 - [Socket Consumption API](/architecture/components/socket_consumption_api) - For components that use network sockets

--- a/src/content/docs/architecture/components/advanced.md
+++ b/src/content/docs/architecture/components/advanced.md
@@ -368,28 +368,20 @@ void IRAM_ATTR MyComponent::gpio_isr(MyComponent *arg) {
 
 ## Hiding Entities at Boot
 
-`EntityBase::set_internal(bool)` changes whether an entity is exposed outside ESPHome (API, MQTT, web server, Prometheus). Prefer the `internal:` YAML key whenever possible: it is guaranteed and has none of the limitations below. Use `set_internal()` only when the decision can only be made at boot. It is only valid before setup finishes: call it from `on_boot` at the default priority, or from a component's `setup()` that runs above `setup_priority::AFTER_WIFI`. Calls after setup log an error and are ignored.
-
-The typical case is one firmware serving several hardware variants, with the variant decided once per boot from a stored preference:
+Prefer the `internal:` YAML key; it is guaranteed and has none of the limitations below. When the decision can only be made at boot, `EntityBase::set_internal(bool)` may be called from `on_boot` at the default priority or from a `setup()` above `setup_priority::AFTER_WIFI`. Calls after setup log an error and are ignored.
 
 ```yaml
 esphome:
   on_boot:
     then:
-      - lambda: |-
-          bool single_unit = id(setup_pref).load();
-          id(hp2_temperature).set_internal(single_unit);
-          id(hp2_power).set_internal(single_unit);
+      - lambda: id(hp2_temperature).set_internal(id(setup_pref).load());
 ```
 
-### Limitations
+Known limitations, not bugs; a PR removing one with no RAM or performance cost would be considered:
 
-These are known limitations, not bugs, so please do not open issue reports for them. A PR that removes one with no RAM or performance cost would be considered.
-
-- No consumer is notified of a change, so the flag can only be decided once per boot.
-- A call from a priority below `AFTER_WIFI` still passes the guard, but MQTT (`AFTER_CONNECTION`) and the API camera listener (`AFTER_WIFI`) have already read the flag and keep the old value. An API client that connects while setup is stalled on a slow component has also already listed the entities.
-- Un-hiding an entity declared `internal: true` in YAML skips the duplicate name check codegen runs for exposed entities, so a name collision can surface at runtime. Entities with only an `id:` are forced internal and use the id as their name.
-- Zigbee codegen skips YAML internal entities entirely, so un-hiding cannot add them to Zigbee.
+- Consumers are not notified, so the flag is decided once per boot.
+- Below `AFTER_WIFI`, MQTT and the API camera listener have already read the flag.
+- Un-hiding a YAML `internal: true` entity skips the duplicate name check, and Zigbee never registers it.
 
 ## See Also
 

--- a/src/content/docs/blog/2026/03/12/icon-and-device-class-getter-migration.md
+++ b/src/content/docs/blog/2026/03/12/icon-and-device-class-getter-migration.md
@@ -51,7 +51,7 @@ The following `EntityBase` setters have been removed and packed into the existin
 - `set_icon()`
 - `set_device_class()`
 - `set_unit_of_measurement()`
-- `set_internal()` (kept for existing projects that call it during setup since 2026.10.0, not recommended for new code, see [Hiding Entities at Boot](/architecture/components/advanced#hiding-entities-at-boot))
+- `set_internal()` (supported again during setup since 2026.10.0, prefer the `internal:` YAML key when possible, see [Hiding Entities at Boot](/architecture/components/advanced#hiding-entities-at-boot))
 - `set_disabled_by_default()`
 - `set_entity_category()`
 

--- a/src/content/docs/blog/2026/03/12/icon-and-device-class-getter-migration.md
+++ b/src/content/docs/blog/2026/03/12/icon-and-device-class-getter-migration.md
@@ -51,7 +51,7 @@ The following `EntityBase` setters have been removed and packed into the existin
 - `set_icon()`
 - `set_device_class()`
 - `set_unit_of_measurement()`
-- `set_internal()`
+- `set_internal()` (supported again during setup since 2026.10.0, see [Hiding Entities at Boot](/architecture/components/advanced#hiding-entities-at-boot))
 - `set_disabled_by_default()`
 - `set_entity_category()`
 

--- a/src/content/docs/blog/2026/03/12/icon-and-device-class-getter-migration.md
+++ b/src/content/docs/blog/2026/03/12/icon-and-device-class-getter-migration.md
@@ -51,7 +51,7 @@ The following `EntityBase` setters have been removed and packed into the existin
 - `set_icon()`
 - `set_device_class()`
 - `set_unit_of_measurement()`
-- `set_internal()` (supported again during setup since 2026.10.0, see [Hiding Entities at Boot](/architecture/components/advanced#hiding-entities-at-boot))
+- `set_internal()` (kept for existing projects that call it during setup since 2026.10.0, not recommended for new code, see [Hiding Entities at Boot](/architecture/components/advanced#hiding-entities-at-boot))
 - `set_disabled_by_default()`
 - `set_entity_category()`
 

--- a/src/content/docs/blog/2026/03/12/icon-and-device-class-getter-migration.md
+++ b/src/content/docs/blog/2026/03/12/icon-and-device-class-getter-migration.md
@@ -51,13 +51,13 @@ The following `EntityBase` setters have been removed and packed into the existin
 - `set_icon()`
 - `set_device_class()`
 - `set_unit_of_measurement()`
-- `set_internal()` (supported again during setup since 2026.10.0, prefer the `internal:` YAML key when possible, see [Hiding Entities at Boot](/architecture/components/advanced#hiding-entities-at-boot))
+- `set_internal()` (supported again during setup starting with 2026.10.0, prefer the `internal:` YAML key when possible, see [Hiding Entities at Boot](/architecture/components/advanced#hiding-entities-at-boot))
 - `set_disabled_by_default()`
 - `set_entity_category()`
 
 Additionally, `set_device()` has been renamed to `set_device_()` and made `protected`.
 
-These were codegen-only setters — calling them at runtime was unsafe and could silently corrupt state or crash the device (undefined behavior). If you were calling `set_icon()` from lambdas to dynamically change icons at runtime, move the icon logic to the Home Assistant side (e.g., using template sensors with `icon` templates).
+These were codegen-only setters — calling them at runtime was unsafe and could silently corrupt state or crash the device (undefined behavior). `set_internal()` is the exception starting with 2026.10.0, the rest remain codegen-only. If you were calling `set_icon()` from lambdas to dynamically change icons at runtime, move the icon logic to the Home Assistant side (e.g., using template sensors with `icon` templates).
 
 See [PR #14171](https://github.com/esphome/esphome/pull/14171), [PR #14437](https://github.com/esphome/esphome/pull/14437), [PR #14443](https://github.com/esphome/esphome/pull/14443), and [PR #14564](https://github.com/esphome/esphome/pull/14564).
 
@@ -163,7 +163,8 @@ grep -rn 'get_device_class_ref\|get_device_class()' your_component/
 grep -rn 'traits\.get_device_class\|traits\.get_unit_of_measurement' your_component/
 
 # Find removed EntityBase setters
-grep -rn 'set_icon\|set_device_class\|set_unit_of_measurement\|set_internal\|set_disabled_by_default\|set_entity_category\|set_name(' your_component/
+grep -rn 'set_icon\|set_device_class\|set_unit_of_measurement\|set_disabled_by_default\|set_entity_category\|set_name(' your_component/
+# set_internal() is supported again during setup starting with 2026.10.0, see "Hiding Entities at Boot"
 ```
 
 ## Questions?


### PR DESCRIPTION
Companion to esphome/esphome#19069: when `set_internal()` may be called, the `can_proceed()` handshake pattern, and the known limitations.